### PR TITLE
Fix bug where nested "bytes" property fails with TypeError

### DIFF
--- a/src/converters/BindingConverters.ts
+++ b/src/converters/BindingConverters.ts
@@ -48,18 +48,23 @@ function isBindingDirection(input: string | undefined): boolean {
 export function convertKeysToCamelCase(obj: any) {
     const output = {};
     for (const key in obj) {
-        // Only "undefined" will be replaced with original object property. For example:
-        //{ string : "0" } -> 0
-        //{ string : "false" } -> false
-        //"test" -> "test" (undefined returned from fromTypedData)
-        const valueFromDataType = fromTypedData(obj[key]);
-        const value = valueFromDataType === undefined ? obj[key] : valueFromDataType;
         const camelCasedKey = key.charAt(0).toLocaleLowerCase() + key.slice(1);
-        // If the value is a JSON object (and not array and not http, which is already cased), convert keys to camel case
-        if (!Array.isArray(value) && typeof value === 'object' && value && value.http == undefined) {
-            output[camelCasedKey] = convertKeysToCamelCase(value);
-        } else {
-            output[camelCasedKey] = value;
+        try {
+            // Only "undefined" will be replaced with original object property. For example:
+            //{ string : "0" } -> 0
+            //{ string : "false" } -> false
+            //"test" -> "test" (undefined returned from fromTypedData)
+            const valueFromDataType = fromTypedData(obj[key]);
+            const value = valueFromDataType === undefined ? obj[key] : valueFromDataType;
+            // If the value is a JSON object (and not array and not http, which is already cased), convert keys to camel case
+            if (!Array.isArray(value) && typeof value === 'object' && value && value.http == undefined) {
+                output[camelCasedKey] = convertKeysToCamelCase(value);
+            } else {
+                output[camelCasedKey] = value;
+            }
+        } catch {
+            // Just use the original value if we failed to recursively convert for any reason
+            output[camelCasedKey] = obj[key];
         }
     }
     return output;

--- a/test/converters/BindingConverters.test.ts
+++ b/test/converters/BindingConverters.test.ts
@@ -110,6 +110,23 @@ describe('Binding Converters', () => {
         expect(bindingData.sys.UtcNow).to.be.undefined;
     });
 
+    it('normalizes binding trigger metadata with bytes as number', () => {
+        // Test to cover this bug:
+        // https://github.com/Azure/azure-functions-nodejs-worker/issues/607
+        const request: RpcInvocationRequest = <RpcInvocationRequest>{
+            triggerMetadata: {
+                A: {
+                    data: 'json',
+                    json: '{"B":{"bytes":4}}',
+                },
+            },
+            invocationId: '12341',
+        };
+
+        const bindingData = getNormalizedBindingData(request);
+        expect(bindingData.a).to.deep.equal({ b: { bytes: 4 } });
+    });
+
     it('catologues binding definitions', () => {
         const functionMetaData: RpcFunctionMetadata = <RpcFunctionMetadata>{
             name: 'MyFunction',


### PR DESCRIPTION
If you try to send an http body with a nested "bytes" property that is a number it currently fails to execute.
Example request:
```
curl -X POST http://localhost:7071/api/helloWorld -d '{ "a": { "b": { "bytes": 4 }}}'
```

Error:
> TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type number (4)

The root of the problem is a combination of our `fromTypedData` and `convertKeysToCamelCase` methods. I think both have some fundamental issues, but I'm wary of refactoring because it might break people relying on the existing behavior. For now, I think it's good enough for us to catch any error and use the original value. I will save bigger refactors for the new programming model.

Fixes https://github.com/Azure/azure-functions-nodejs-worker/issues/607