### PR TITLE
Add HttpRequest.get method to types

### DIFF
--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -22,6 +22,7 @@ const runHttp: AzureFunction = async function (context: Context, req: HttpReques
         context.log("This is a 'GET' method");
     }
 
+    context.log(`Header: ${req.get('X-CUSTOM-HEADER')}`);
     context.log('JavaScript HTTP trigger function processed a request.');
     if (req.query.name || (req.body && req.body.name)) {
         context.res = {

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -109,6 +109,11 @@ export interface HttpRequest {
     bufferBody?: Buffer;
 
     /**
+     * Get the value of a particular header field
+     */
+    get(field: string): string | undefined;
+
+    /**
      * Parses the body and returns an object representing a form
      * @throws if the content type is not "multipart/form-data" or "application/x-www-form-urlencoded"
      */


### PR DESCRIPTION
It's the recommended way to get a header because it works regardless of casing

Related to https://github.com/Azure/azure-functions-nodejs-worker/issues/274