### PR TITLE
Make RPC HTTP converter copy input by value

### DIFF
--- a/src/converters/RpcHttpConverters.ts
+++ b/src/converters/RpcHttpConverters.ts
@@ -55,14 +55,15 @@ export function fromNullableMapping(
  * 'http' types are a special case from other 'ITypedData' types, which come from primitive types.
  * @param inputMessage  An HTTP response object
  */
-export function toRpcHttp(inputMessage: HttpResponse): RpcTypedData {
+export function toRpcHttp(data: unknown): RpcTypedData {
     // Check if we will fail to find any of these
-    if (typeof inputMessage !== 'object' || Array.isArray(inputMessage)) {
+    if (typeof data !== 'object' || Array.isArray(data)) {
         throw new AzFuncSystemError(
             "The HTTP response must be an 'object' type that can include properties such as 'body', 'status', and 'headers'. Learn more: https://go.microsoft.com/fwlink/?linkid=2112563"
         );
     }
 
+    const inputMessage: HttpResponse = data || {};
     let status = inputMessage.statusCode;
     if (typeof inputMessage.status !== 'function') {
         status ||= inputMessage.status;

--- a/test/converters/BindingConverters.test.ts
+++ b/test/converters/BindingConverters.test.ts
@@ -7,12 +7,11 @@ import { fromString } from 'long';
 import 'mocha';
 import { getBindingDefinitions, getNormalizedBindingData } from '../../src/converters/BindingConverters';
 import { fromTypedData } from '../../src/converters/RpcConverters';
-import { toRpcHttp } from '../../src/converters/RpcHttpConverters';
 import { FunctionInfo } from '../../src/FunctionInfo';
 
 describe('Binding Converters', () => {
     it('normalizes binding trigger metadata for HTTP', () => {
-        const mockRequest: RpcTypedData = toRpcHttp({ url: 'https://mock' });
+        const mockRequest: RpcTypedData = { http: { url: 'https://mock' } };
         const triggerDataMock: { [k: string]: RpcTypedData } = {
             Headers: {
                 json: JSON.stringify({ Connection: 'Keep-Alive' }),

--- a/test/converters/RpcHttpConverters.test.ts
+++ b/test/converters/RpcHttpConverters.test.ts
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Cookie } from '@azure/functions';
+import { Cookie, HttpResponse } from '@azure/functions';
 import { expect } from 'chai';
 import 'mocha';
+import { toTypedData } from '../../src/converters/RpcConverters';
 import { toRpcHttp, toRpcHttpCookieList } from '../../src/converters/RpcHttpConverters';
 
 describe('Rpc Converters', () => {
@@ -113,6 +114,7 @@ describe('Rpc Converters', () => {
     it('throws on array as http response', () => {
         expect(() => {
             const response = ['one', 2, '3'];
+            // @ts-expect-error: passing wrong type
             toRpcHttp(response);
         }).to.throw(
             "The HTTP response must be an 'object' type that can include properties such as 'body', 'status', and 'headers'. Learn more: https://go.microsoft.com/fwlink/?linkid=2112563"
@@ -122,9 +124,19 @@ describe('Rpc Converters', () => {
     it('throws on string as http response', () => {
         expect(() => {
             const response = 'My output string';
+            // @ts-expect-error: passing wrong type
             toRpcHttp(response);
         }).to.throw(
             "The HTTP response must be an 'object' type that can include properties such as 'body', 'status', and 'headers'. Learn more: https://go.microsoft.com/fwlink/?linkid=2112563"
         );
+    });
+
+    it('copies by value', () => {
+        const response: HttpResponse = {
+            body: 'before',
+        };
+        const converted = toRpcHttp(response);
+        response.body = 'after';
+        expect(converted.http?.body).to.deep.equal(toTypedData('before'));
     });
 });

--- a/test/converters/RpcHttpConverters.test.ts
+++ b/test/converters/RpcHttpConverters.test.ts
@@ -114,7 +114,6 @@ describe('Rpc Converters', () => {
     it('throws on array as http response', () => {
         expect(() => {
             const response = ['one', 2, '3'];
-            // @ts-expect-error: passing wrong type
             toRpcHttp(response);
         }).to.throw(
             "The HTTP response must be an 'object' type that can include properties such as 'body', 'status', and 'headers'. Learn more: https://go.microsoft.com/fwlink/?linkid=2112563"
@@ -124,7 +123,6 @@ describe('Rpc Converters', () => {
     it('throws on string as http response', () => {
         expect(() => {
             const response = 'My output string';
-            // @ts-expect-error: passing wrong type
             toRpcHttp(response);
         }).to.throw(
             "The HTTP response must be an 'object' type that can include properties such as 'body', 'status', and 'headers'. Learn more: https://go.microsoft.com/fwlink/?linkid=2112563"


### PR DESCRIPTION
Fixes #13. This PR modifies the `toRpcHttp` function such that it copies the provided HTTP response object rather than modifying it in-place, and therefore preventing future alterations to the input from affecting the output of the function. Also enforces stricter types on the input.