### PR TITLE
Don't ignore return value of functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,6 @@
             2
         ],
         "deprecation/deprecation": "error",
-        "@typescript/no-unsafe-assignment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-namespace": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint", "header", "deprecation"],
+    "plugins": [
+        "@typescript-eslint",
+        "header",
+        "deprecation"
+    ],
     "parserOptions": {
         "project": "tsconfig.json",
         "sourceType": "module"
@@ -15,7 +19,10 @@
         "header/header": [
             2,
             "line",
-            [" Copyright (c) .NET Foundation. All rights reserved.", " Licensed under the MIT License."],
+            [
+                " Copyright (c) .NET Foundation. All rights reserved.",
+                " Licensed under the MIT License."
+            ],
             2
         ],
         "deprecation/deprecation": "error",
@@ -25,8 +32,7 @@
         "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "prefer-const": ["error", { "destructuring": "all" }],
         "@typescript-eslint/explicit-member-accessibility": [
-            "error",
-            {
+            "error", {
                 "accessibility": "no-public"
             }
         ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
     "parser": "@typescript-eslint/parser",
-    "plugins": [
-        "@typescript-eslint",
-        "header",
-        "deprecation"
-    ],
+    "plugins": ["@typescript-eslint", "header", "deprecation"],
     "parserOptions": {
         "project": "tsconfig.json",
         "sourceType": "module"
@@ -19,28 +15,22 @@
         "header/header": [
             2,
             "line",
-            [
-                " Copyright (c) .NET Foundation. All rights reserved.",
-                " Licensed under the MIT License."
-            ],
+            [" Copyright (c) .NET Foundation. All rights reserved.", " Licensed under the MIT License."],
             2
         ],
         "deprecation/deprecation": "error",
+        "@typescript/no-unsafe-assignment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "prefer-const": ["error", { "destructuring": "all" }],
         "@typescript-eslint/explicit-member-accessibility": [
-            "error", {
+            "error",
+            {
                 "accessibility": "no-public"
             }
         ]
     },
-    "ignorePatterns": [
-        "**/*.js",
-        "**/*.mjs",
-        "**/*.cjs",
-        "dist"
-    ]
+    "ignorePatterns": ["**/*.js", "**/*.mjs", "**/*.cjs", "dist"]
 }

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -104,6 +104,10 @@ export class InvocationModel implements coreTypes.InvocationModel {
             }
         }
 
+        if (!response.returnValue && response.outputData.length == 0 /* && !info.hasHttpTrigger*/) {
+            response.returnValue = toRpcTypedData(result);
+        }
+
         return response;
     }
 

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -104,9 +104,9 @@ export class InvocationModel implements coreTypes.InvocationModel {
             }
         }
 
-        // This piece of code allows the return value of non-HTTP triggered functions to be passed back
-        // to the host, even if no explicit output binding is set mapping to the return value.
-        // E.g., this is used in Durable to pass orchestrator state back to the Durable extension, w/o
+        // This allows the return value of non-HTTP triggered functions to be passed back
+        // to the host, even if no explicit output binding is set. In most cases, this is ignored,
+        // but e.g., Durable uses this to pass orchestrator state back to the Durable extension, w/o
         // an explicit output binding. See here for more details: https://github.com/Azure/azure-functions-nodejs-library/pull/25
         if (!response.returnValue && response.outputData.length == 0 && !isHttpTrigger(this.#triggerType)) {
             response.returnValue = toRpcTypedData(result);

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -21,7 +21,7 @@ import { toCamelCaseValue } from './converters/toCamelCase';
 import { toRpcHttp } from './converters/toRpcHttp';
 import { toRpcTypedData } from './converters/toRpcTypedData';
 import { InvocationContext } from './InvocationContext';
-import { isTimerTrigger, isTrigger } from './utils/isTrigger';
+import { isHttpTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
 import { nonNullProp, nonNullValue } from './utils/nonNull';
 
 export class InvocationModel implements coreTypes.InvocationModel {
@@ -104,7 +104,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
             }
         }
 
-        if (!response.returnValue && response.outputData.length == 0) {
+        if (!response.returnValue && response.outputData.length == 0 && !isHttpTrigger(this.#triggerType)) {
             response.returnValue = toRpcTypedData(result);
         }
 

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -104,7 +104,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
             }
         }
 
-        if (!response.returnValue && response.outputData.length == 0 /* && !info.hasHttpTrigger*/) {
+        if (!response.returnValue && response.outputData.length == 0) {
             response.returnValue = toRpcTypedData(result);
         }
 

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -104,6 +104,10 @@ export class InvocationModel implements coreTypes.InvocationModel {
             }
         }
 
+        // This piece of code allows the return value of non-HTTP triggered functions to be passed back
+        // to the host, even if no explicit output binding is set mapping to the return value.
+        // E.g., this is used in Durable to pass orchestrator state back to the Durable extension, w/o
+        // an explicit output binding. See here for more details: https://github.com/Azure/azure-functions-nodejs-library/pull/25
         if (!response.returnValue && response.outputData.length == 0 && !isHttpTrigger(this.#triggerType)) {
             response.returnValue = toRpcTypedData(result);
         }

--- a/types/InvocationContext.d.ts
+++ b/types/InvocationContext.d.ts
@@ -113,10 +113,6 @@ export interface InvocationContextExtraInputs {
      */
     get(inputOrName: FunctionInput | string): unknown;
 
-    getMetadata(name: string): FunctionInput;
-
-    getNamesOfType(type: string): string[];
-
     /**
      * Set a secondary generic input for this invocation
      * @inputOrName the configuration object or name for this input

--- a/types/InvocationContext.d.ts
+++ b/types/InvocationContext.d.ts
@@ -109,13 +109,17 @@ export interface InvocationContextExtraInputs {
 
     /**
      * Get a secondary generic input for this invocation
-     * @outputOrName the configuration object or name for this input
+     * @inputOrName the configuration object or name for this input
      */
     get(inputOrName: FunctionInput | string): unknown;
 
+    getMetadata(name: string): FunctionInput;
+
+    getNamesOfType(type: string): string[];
+
     /**
      * Set a secondary generic input for this invocation
-     * @outputOrName the configuration object or name for this input
+     * @inputOrName the configuration object or name for this input
      * @value the input value
      */
     set(inputOrName: FunctionInput | string, value: unknown): void;


### PR DESCRIPTION
This PR makes it such that return values of functions are not ignored, and instead set as the `returnValue` property of the gRPC `functionInvocationResponse` message, even if no explicit output binding is set. This helps in cases such as Durable Functions where the function invocation is invoked programmatically and the return value is used without an explicit output binding