### PR TITLE
Removing `methods` property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
     HttpFunctionOptions,
     HttpHandler,
     HttpMethod,
+    HttpMethodFunctionOptions,
     HttpOutput,
     HttpOutputOptions,
     HttpTrigger,
@@ -113,23 +114,23 @@ function convertToHttpOptions(
 }
 
 export namespace app {
-    export function get(name: string, optionsOrHandler: HttpFunctionOptions | HttpHandler): void {
+    export function get(name: string, optionsOrHandler: HttpMethodFunctionOptions | HttpHandler): void {
         http(name, convertToHttpOptions(optionsOrHandler, 'GET'));
     }
 
-    export function put(name: string, optionsOrHandler: HttpFunctionOptions | HttpHandler): void {
+    export function put(name: string, optionsOrHandler: HttpMethodFunctionOptions | HttpHandler): void {
         http(name, convertToHttpOptions(optionsOrHandler, 'PUT'));
     }
 
-    export function post(name: string, optionsOrHandler: HttpFunctionOptions | HttpHandler): void {
+    export function post(name: string, optionsOrHandler: HttpMethodFunctionOptions | HttpHandler): void {
         http(name, convertToHttpOptions(optionsOrHandler, 'POST'));
     }
 
-    export function patch(name: string, optionsOrHandler: HttpFunctionOptions | HttpHandler): void {
+    export function patch(name: string, optionsOrHandler: HttpMethodFunctionOptions | HttpHandler): void {
         http(name, convertToHttpOptions(optionsOrHandler, 'PATCH'));
     }
 
-    export function deleteRequest(name: string, optionsOrHandler: HttpFunctionOptions | HttpHandler): void {
+    export function deleteRequest(name: string, optionsOrHandler: HttpMethodFunctionOptions | HttpHandler): void {
         http(name, convertToHttpOptions(optionsOrHandler, 'DELETE'));
     }
 

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -22,6 +22,8 @@ export interface HttpFunctionOptions extends HttpTriggerOptions, Partial<Functio
     return?: FunctionOutput;
 }
 
+export type HttpMethodFunctionOptions = Omit<HttpFunctionOptions, 'methods'>;
+
 export interface HttpTriggerOptions {
     /**
      * The function HTTP authorization level

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,7 @@ import {
     HttpOutputOptions,
     HttpTrigger,
     HttpTriggerOptions,
+    HttpMethodFunctionOptions,
 } from './http';
 import { InvocationContext } from './InvocationContext';
 import {
@@ -95,7 +96,7 @@ export namespace app {
      * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
      * @param options Configuration options describing the inputs, outputs, and handler for this function
      */
-    export function get(name: string, options: HttpFunctionOptions): void;
+    export function get(name: string, options: HttpMethodFunctionOptions): void;
 
     /**
      * Registers an http function in your app that will be triggered by making a 'PUT' request to the function url
@@ -109,7 +110,7 @@ export namespace app {
      * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
      * @param options Configuration options describing the inputs, outputs, and handler for this function
      */
-    export function put(name: string, options: HttpFunctionOptions): void;
+    export function put(name: string, options: HttpMethodFunctionOptions): void;
 
     /**
      * Registers an http function in your app that will be triggered by making a 'POST' request to the function url
@@ -123,7 +124,7 @@ export namespace app {
      * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
      * @param options Configuration options describing the inputs, outputs, and handler for this function
      */
-    export function post(name: string, options: HttpFunctionOptions): void;
+    export function post(name: string, options: HttpMethodFunctionOptions): void;
 
     /**
      * Registers an http function in your app that will be triggered by making a 'PATCH' request to the function url
@@ -137,7 +138,7 @@ export namespace app {
      * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
      * @param options Configuration options describing the inputs, outputs, and handler for this function
      */
-    export function patch(name: string, options: HttpFunctionOptions): void;
+    export function patch(name: string, options: HttpMethodFunctionOptions): void;
 
     /**
      * Registers an http function in your app that will be triggered by making a 'DELETE' request to the function url
@@ -151,7 +152,7 @@ export namespace app {
      * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
      * @param options Configuration options describing the inputs, outputs, and handler for this function
      */
-    export function deleteRequest(name: string, options: HttpFunctionOptions): void;
+    export function deleteRequest(name: string, options: HttpMethodFunctionOptions): void;
 
     /**
      * Registers a timer function in your app that will be triggered on a schedule


### PR DESCRIPTION
Addressing #38 

The `methods` property is now omitted from the type signature of `HttpFunctionOptions` if you're using the `get`/`post`/etc. shortcut methods to define a HTTP Trigger Function.