### PR TITLE
Use undici request properties more directly

### DIFF
--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as types from '@azure/functions';
-import { HttpMethod, HttpRequestParams, HttpRequestUser } from '@azure/functions';
+import { HttpRequestParams, HttpRequestUser } from '@azure/functions';
 import { RpcHttpData } from '@azure/functions-core';
 import { Blob } from 'buffer';
 import { ReadableStream } from 'stream/web';
@@ -13,11 +13,8 @@ import { nonNullProp } from '../utils/nonNull';
 import { extractHttpUserFromHeaders } from './extractHttpUserFromHeaders';
 
 export class HttpRequest implements types.HttpRequest {
-    method: HttpMethod;
-    url: string;
-    headers: Headers;
-    query: URLSearchParams;
-    params: HttpRequestParams;
+    readonly query: URLSearchParams;
+    readonly params: HttpRequestParams;
 
     #cachedUser?: HttpRequestUser | null;
     #uReq: uRequest;
@@ -38,11 +35,20 @@ export class HttpRequest implements types.HttpRequest {
             headers: fromNullableMapping(rpcHttp.nullableHeaders, rpcHttp.headers),
         });
 
-        this.method = <HttpMethod>nonNullProp(rpcHttp, 'method');
-        this.url = url;
-        this.headers = this.#uReq.headers;
         this.query = new URLSearchParams(fromNullableMapping(rpcHttp.nullableQuery, rpcHttp.query));
         this.params = fromNullableMapping(rpcHttp.nullableParams, rpcHttp.params);
+    }
+
+    get url(): string {
+        return this.#uReq.url;
+    }
+
+    get method(): string {
+        return this.#uReq.method;
+    }
+
+    get headers(): Headers {
+        return this.#uReq.headers;
     }
 
     get user(): HttpRequestUser | null {

--- a/test/converters/fromRpcTypedData.test.ts
+++ b/test/converters/fromRpcTypedData.test.ts
@@ -59,7 +59,7 @@ describe('fromRpcTypedData', () => {
         });
         expect(result).to.be.instanceOf(HttpRequest);
         expect(await result.text()).to.equal('test');
-        expect(result.url).to.equal('http://microsoft.com');
+        expect(result.url).to.equal('http://microsoft.com/');
     });
 
     it('int', () => {

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -79,34 +79,34 @@ export declare class HttpRequest {
     /**
      * HTTP request method used to invoke this function.
      */
-    method: HttpMethod;
+    readonly method: string;
 
     /**
      * Request URL.
      */
-    url: string;
+    readonly url: string;
 
     /**
      * HTTP request headers.
      */
-    headers: Headers;
+    readonly headers: Headers;
 
     /**
      * Query string parameter keys and values from the URL.
      */
-    query: URLSearchParams;
+    readonly query: URLSearchParams;
 
     /**
      * Route parameter keys and values.
      */
-    params: HttpRequestParams;
+    readonly params: HttpRequestParams;
 
     /**
      *  Object representing logged-in user, either through
      *  AppService/Functions authentication, or SWA Authentication
      *  null when no such user is logged in.
      */
-    user: HttpRequestUser | null;
+    readonly user: HttpRequestUser | null;
 
     /**
      * Returns the body as a ReadableStream
@@ -273,7 +273,7 @@ export interface Cookie {
  * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
  */
 export interface HttpRequestInit {
-    method?: HttpMethod;
+    method?: string;
 
     url?: string;
 


### PR DESCRIPTION
Similar goal as https://github.com/Azure/azure-functions-nodejs-library/pull/44, but much smaller scope. I just want to be more consistent with undici (which uses `readonly` on basically all class properties) and directly reference those properties instead of referencing the rpc ones in our constructor.