### PR TITLE
Add `HttpResponse` class and model it after undici

### DIFF
--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -86,7 +86,6 @@ export class InvocationModel implements coreTypes.InvocationModel {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     async getResponse(context: InvocationContext, result: unknown): Promise<RpcInvocationResponse> {
         const response: RpcInvocationResponse = { invocationId: this.#coreCtx.invocationId };
 
@@ -94,11 +93,11 @@ export class InvocationModel implements coreTypes.InvocationModel {
         for (const [name, binding] of Object.entries(this.#bindings)) {
             if (binding.direction === 'out') {
                 if (name === returnBindingKey) {
-                    response.returnValue = this.#convertOutput(binding, result);
+                    response.returnValue = await this.#convertOutput(binding, result);
                 } else {
                     response.outputData.push({
                         name,
-                        data: this.#convertOutput(binding, context.extraOutputs.get(name)),
+                        data: await this.#convertOutput(binding, context.extraOutputs.get(name)),
                     });
                 }
             }
@@ -115,9 +114,9 @@ export class InvocationModel implements coreTypes.InvocationModel {
         return response;
     }
 
-    #convertOutput(binding: RpcBindingInfo, value: unknown): RpcTypedData | null | undefined {
+    async #convertOutput(binding: RpcBindingInfo, value: unknown): Promise<RpcTypedData | null | undefined> {
         if (binding.type?.toLowerCase() === 'http') {
-            return toRpcHttp(value);
+            return await toRpcHttp(value);
         } else {
             return toRpcTypedData(value);
         }

--- a/src/converters/toRpcHttp.ts
+++ b/src/converters/toRpcHttp.ts
@@ -1,14 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { HttpResponse } from '@azure/functions';
 import { RpcHttpData, RpcTypedData } from '@azure/functions-core';
-import { Headers } from 'undici';
 import { AzFuncSystemError } from '../errors';
+import { HttpResponse } from '../http/HttpResponse';
 import { toRpcHttpCookie } from './toRpcHttpCookie';
 import { toRpcTypedData } from './toRpcTypedData';
 
-export function toRpcHttp(data: unknown): RpcTypedData | null | undefined {
+export async function toRpcHttp(data: unknown): Promise<RpcTypedData | null | undefined> {
     if (data === null || data === undefined) {
         return data;
     } else if (typeof data !== 'object') {
@@ -16,32 +15,25 @@ export function toRpcHttp(data: unknown): RpcTypedData | null | undefined {
             'The HTTP response must be an object with optional properties "body", "status", "headers", and "cookies".'
         );
     }
-    const response: HttpResponse = data;
 
+    const response = data instanceof HttpResponse ? data : new HttpResponse(data);
     const rpcResponse: RpcHttpData = {};
-    rpcResponse.body = toRpcTypedData(response.body);
-    if (response.status !== null && response.status !== undefined) {
-        if (typeof response.status !== 'string' && typeof response.status !== 'number') {
-            throw new AzFuncSystemError('The HTTP response "status" property must be of type "number" or "string".');
-        } else {
-            rpcResponse.statusCode = response.status.toString();
-        }
-    }
+    rpcResponse.statusCode = response.status.toString();
 
     rpcResponse.headers = {};
-    if (response.headers !== null && response.headers !== undefined) {
-        const headers = new Headers(response.headers);
-        for (const [key, value] of headers.entries()) {
-            rpcResponse.headers[key] = value;
-        }
+    for (const [key, value] of response.headers.entries()) {
+        rpcResponse.headers[key] = value;
     }
 
     rpcResponse.cookies = [];
-    if (response.cookies !== null && response.cookies !== undefined) {
-        for (const cookie of response.cookies) {
-            rpcResponse.cookies.push(toRpcHttpCookie(cookie));
-        }
+    for (const cookie of response.cookies) {
+        rpcResponse.cookies.push(toRpcHttpCookie(cookie));
     }
+
+    rpcResponse.enableContentNegotiation = response.enableContentNegotiation;
+
+    const bodyBytes = await response.arrayBuffer();
+    rpcResponse.body = toRpcTypedData(bodyBytes);
 
     return { http: rpcResponse };
 }

--- a/src/converters/toRpcTypedData.ts
+++ b/src/converters/toRpcTypedData.ts
@@ -13,6 +13,9 @@ export function toRpcTypedData(data: unknown): RpcTypedData | null | undefined {
     } else if (ArrayBuffer.isView(data)) {
         const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
         return { bytes: bytes };
+    } else if (data instanceof ArrayBuffer) {
+        const bytes = new Uint8Array(data);
+        return { bytes: bytes };
     } else if (typeof data === 'number') {
         if (Number.isInteger(data)) {
             return { int: data };

--- a/src/http/HttpResponse.ts
+++ b/src/http/HttpResponse.ts
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { HttpResponseInit } from '@azure/functions';
+import { Blob } from 'buffer';
+import { ReadableStream } from 'stream/web';
+import { FormData, Headers, Response as uResponse, ResponseInit as uResponseInit } from 'undici';
+import { isDefined } from '../utils/nonNull';
+
+export class HttpResponse implements types.HttpResponse {
+    readonly cookies: types.Cookie[];
+    readonly enableContentNegotiation: boolean;
+
+    #uRes: uResponse;
+
+    constructor(resInit?: HttpResponseInit) {
+        const uResInit: uResponseInit = { status: resInit?.status, headers: resInit?.headers };
+        if (isDefined(resInit?.jsonBody)) {
+            this.#uRes = uResponse.json(resInit?.jsonBody, uResInit);
+        } else {
+            this.#uRes = new uResponse(resInit?.body, uResInit);
+        }
+
+        this.cookies = resInit?.cookies || [];
+        this.enableContentNegotiation = !!resInit?.enableContentNegotiation;
+    }
+
+    get status(): number {
+        return this.#uRes.status;
+    }
+
+    get headers(): Headers {
+        return this.#uRes.headers;
+    }
+
+    get body(): ReadableStream<any> | null {
+        return this.#uRes.body;
+    }
+
+    get bodyUsed(): boolean {
+        return this.#uRes.bodyUsed;
+    }
+
+    async arrayBuffer(): Promise<ArrayBuffer> {
+        return await this.#uRes.arrayBuffer();
+    }
+
+    async blob(): Promise<Blob> {
+        return await this.#uRes.blob();
+    }
+
+    async formData(): Promise<FormData> {
+        return await this.#uRes.formData();
+    }
+
+    async json(): Promise<unknown> {
+        return await this.#uRes.json();
+    }
+
+    async text(): Promise<string> {
+        return await this.#uRes.text();
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import { InvocationModel } from './InvocationModel';
 import { isTrigger } from './utils/isTrigger';
 
 export { HttpRequest } from './http/HttpRequest';
+export { HttpResponse } from './http/HttpResponse';
 export { InvocationContext } from './InvocationContext';
 
 let coreApi: typeof coreTypes | undefined | null;

--- a/test/converters/toRpcHttp.test.ts
+++ b/test/converters/toRpcHttp.test.ts
@@ -1,102 +1,126 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as chai from 'chai';
 import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import 'mocha';
 import { Headers } from 'undici';
 import { toRpcHttp } from '../../src/converters/toRpcHttp';
+import { HttpResponse } from '../../src/http/HttpResponse';
+chai.use(chaiAsPromised);
 
 describe('toRpcHttp', () => {
-    it('undefined', () => {
-        const result = toRpcHttp({});
-        expect(result?.http?.statusCode).to.be.undefined;
-        expect(result?.http?.body).to.be.undefined;
-        expect(result?.http?.headers).to.deep.equal({});
-        expect(result?.http?.cookies).to.deep.equal([]);
-    });
-
-    it('null', () => {
-        const result = toRpcHttp({
-            body: null,
-            status: null,
-            headers: null,
-            cookies: null,
-        });
-        expect(result?.http?.statusCode).to.be.undefined;
-        expect(result?.http?.body).to.be.null;
-        expect(result?.http?.headers).to.deep.equal({});
-        expect(result?.http?.cookies).to.deep.equal([]);
-    });
-
-    it('array (weird, but still valid)', () => {
-        expect(toRpcHttp(Object.assign([], { body: 'a' }))?.http?.body).to.deep.equal({ string: 'a' });
-    });
-
-    it('invalid data string', () => {
-        expect(() => {
-            toRpcHttp('invalid');
-        }).to.throw(/must be an object/i);
-    });
-
-    it('invalid data boolean', () => {
-        expect(() => {
-            toRpcHttp(true);
-        }).to.throw(/must be an object/i);
-    });
-
-    it('body buffer', () => {
-        expect(toRpcHttp({ body: Buffer.from('b') })?.http?.body).to.deep.equal({ bytes: Buffer.from('b') });
-    });
-
-    it('body number', () => {
-        expect(toRpcHttp({ body: 3 })?.http?.body).to.deep.equal({ int: 3 });
-    });
-
-    it('status number', () => {
-        expect(toRpcHttp({ status: 200 })?.http?.statusCode).to.equal('200');
-    });
-
-    it('status string', () => {
-        expect(toRpcHttp({ status: '500' })?.http?.statusCode).to.equal('500');
-    });
-
-    it('status invalid', () => {
-        expect(() => toRpcHttp({ status: {} })).to.throw(/status.*number.*string/i);
-    });
-
-    it('headers object', () => {
-        expect(
-            toRpcHttp({
-                headers: {
-                    a: 'b',
+    const textPlainHeaders = { 'content-type': 'text/plain;charset=UTF-8' };
+    const jsonHeaders = { 'content-type': 'application/json' };
+    function getExpectedRpcHttp(body: string, headers: Record<string, string>, statusCode = '200') {
+        return {
+            http: {
+                statusCode,
+                body: {
+                    bytes: Buffer.from(body),
                 },
-            })?.http?.headers?.a
-        ).to.equal('b');
+                headers: headers,
+                enableContentNegotiation: false,
+                cookies: [],
+            },
+        };
+    }
+
+    it('hello world', async () => {
+        const result = await toRpcHttp({ body: 'hello world' });
+        expect(result).to.deep.equal(getExpectedRpcHttp('hello world', textPlainHeaders));
     });
 
-    it('headers array', () => {
-        expect(
-            toRpcHttp({
-                headers: [['c', 'd']],
-            })?.http?.headers?.c
-        ).to.equal('d');
+    it('response class hello world', async () => {
+        const result = await toRpcHttp(new HttpResponse({ body: 'hello world' }));
+        expect(result).to.deep.equal(getExpectedRpcHttp('hello world', textPlainHeaders));
     });
 
-    it('headers class', () => {
-        expect(
-            toRpcHttp({
-                headers: new Headers({
-                    e: 'f',
-                }),
-            })?.http?.headers?.e
-        ).to.equal('f');
+    it('response class json', async () => {
+        const result = await toRpcHttp(new HttpResponse({ jsonBody: { hello: 'world' } }));
+        expect(result).to.deep.equal(getExpectedRpcHttp('{"hello":"world"}', jsonHeaders));
     });
 
-    it('headers invalid', () => {
-        expect(() =>
-            toRpcHttp({
-                headers: true,
+    it('response class json manual json', async () => {
+        const req = new HttpResponse({ body: '{ "hello":  "world" }' });
+        req.headers.set('content-type', 'application/json');
+        const result = await toRpcHttp(req);
+        expect(result).to.deep.equal(
+            getExpectedRpcHttp('{ "hello":  "world" }', {
+                'content-type': 'application/json',
             })
-        ).to.throw(/argument.*could not be converted/i);
+        );
+    });
+
+    it('undefined', async () => {
+        const result = await toRpcHttp({});
+        expect(result).to.deep.equal(getExpectedRpcHttp('', {}));
+    });
+
+    it('array (weird, but still valid)', async () => {
+        const result = await toRpcHttp(Object.assign([], { body: 'a' }));
+        expect(result).to.deep.equal(getExpectedRpcHttp('a', textPlainHeaders));
+    });
+
+    it('invalid data string', async () => {
+        await expect(toRpcHttp('invalid')).to.eventually.be.rejectedWith(/must be an object/i);
+    });
+
+    it('invalid data boolean', async () => {
+        await expect(toRpcHttp(true)).to.eventually.be.rejectedWith(/must be an object/i);
+    });
+
+    it('body buffer', async () => {
+        const result = await toRpcHttp({ body: Buffer.from('b') });
+        expect(result).to.deep.equal(getExpectedRpcHttp('b', {}));
+    });
+
+    it('body number', async () => {
+        const result = await toRpcHttp({ body: 3 });
+        expect(result).to.deep.equal(getExpectedRpcHttp('3', textPlainHeaders));
+    });
+
+    it('status number', async () => {
+        const result = await toRpcHttp({ status: 400 });
+        expect(result).to.deep.equal(getExpectedRpcHttp('', {}, '400'));
+    });
+
+    it('status string', async () => {
+        const result = await toRpcHttp({ status: '500' });
+        expect(result).to.deep.equal(getExpectedRpcHttp('', {}, '500'));
+    });
+
+    it('status invalid', async () => {
+        await expect(toRpcHttp({ status: {} })).to.eventually.be.rejectedWith(/status/i);
+    });
+
+    it('headers object', async () => {
+        const result = await toRpcHttp({
+            headers: {
+                a: 'b',
+            },
+        });
+        expect(result?.http?.headers?.a).to.equal('b');
+    });
+
+    it('headers array', async () => {
+        const result = await toRpcHttp({
+            headers: [['c', 'd']],
+        });
+        expect(result?.http?.headers?.c).to.equal('d');
+    });
+
+    it('headers class', async () => {
+        const result = await toRpcHttp({
+            headers: new Headers({
+                e: 'f',
+            }),
+        });
+        expect(result?.http?.headers?.e).to.equal('f');
+    });
+
+    it('headers invalid', async () => {
+        await expect(toRpcHttp({ headers: true })).to.eventually.be.rejectedWith(/argument.*could not be converted/i);
     });
 });


### PR DESCRIPTION
## new class
Here's the current way of returning a response:
```typescript
return { body: `Hello, ${name}!` };
```

In addition to that, you can now use a new `HttpResponse` class:
```typescript
const res = new HttpResponse({ body: `Hello, ${name}!` });
res.headers.set('headerName', 'headerValue');
return res;
```

## using undici's body type

When creating the `HttpResponse` class, I modeled it directly off of undici. The biggest change was around the body type, where I completely ditched ours for undici's. Under the covers, all responses get translated to a buffer by undici before we send the data over rpc. This actually makes our treatment of requests and responses more consistent because all requests come in as a buffer from the host and we let undici handle translating it to string/buffer/form/etc..

Old: 
```typescript
export type HttpResponseBody = string | Buffer | NodeJS.ArrayBufferView | number | object;
```
New (we're directly using undici's type):
```typescript
export type BodyInit =
  | ArrayBuffer
  | AsyncIterable<Uint8Array>
  | Blob
  | FormData
  | Iterable<Uint8Array>
  | NodeJS.ArrayBufferView
  | URLSearchParams
  | null
  | string
```

## json body

Within the BodyInit type, undici has a lot of nice new types we didn't support but there are also a few missing from our old stuff. First, `number` which I don't care about. Second, `object` which is how we handled json which I do care about. I assume undici doesn't list `object` because it would conflict with several of their other types and generally make things ambiguous. Undici supports json bodies through a static `Response.json` method which creates a Response, serializes the body, and adds the `application/json` content-type header. I'm using that method under the covers, but I didn't actually add a similar static method to our class. Instead, I chose to add a `jsonBody` property to our `HttpResponseInit` type so that people could still do json with or without the class. For example:

```typescript
return { jsonBody: { foo: 'bar' } };
return new HttpResponse({ jsonBody: { foo: 'bar' } });
```

Fixes #36