### PR TITLE
Turn on "return-await" eslint rule [v4.x]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,9 @@
             "error", {
                 "accessibility": "no-public"
             }
-        ]
+        ],
+        "no-return-await": "off",
+        "@typescript-eslint/return-await": "error"
     },
     "ignorePatterns": [
         "**/*.js",

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -116,7 +116,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
 
     async #convertOutput(binding: RpcBindingInfo, value: unknown): Promise<RpcTypedData | null | undefined> {
         if (binding.type?.toLowerCase() === 'http') {
-            return await toRpcHttp(value);
+            return toRpcHttp(value);
         } else {
             return toRpcTypedData(value);
         }

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -68,22 +68,22 @@ export class HttpRequest implements types.HttpRequest {
     }
 
     async arrayBuffer(): Promise<ArrayBuffer> {
-        return await this.#uReq.arrayBuffer();
+        return this.#uReq.arrayBuffer();
     }
 
     async blob(): Promise<Blob> {
-        return await this.#uReq.blob();
+        return this.#uReq.blob();
     }
 
     async formData(): Promise<FormData> {
-        return await this.#uReq.formData();
+        return this.#uReq.formData();
     }
 
     async json(): Promise<unknown> {
-        return await this.#uReq.json();
+        return this.#uReq.json();
     }
 
     async text(): Promise<string> {
-        return await this.#uReq.text();
+        return this.#uReq.text();
     }
 }

--- a/src/http/HttpResponse.ts
+++ b/src/http/HttpResponse.ts
@@ -43,22 +43,22 @@ export class HttpResponse implements types.HttpResponse {
     }
 
     async arrayBuffer(): Promise<ArrayBuffer> {
-        return await this.#uRes.arrayBuffer();
+        return this.#uRes.arrayBuffer();
     }
 
     async blob(): Promise<Blob> {
-        return await this.#uRes.blob();
+        return this.#uRes.blob();
     }
 
     async formData(): Promise<FormData> {
-        return await this.#uRes.formData();
+        return this.#uRes.formData();
     }
 
     async json(): Promise<unknown> {
-        return await this.#uRes.json();
+        return this.#uRes.json();
     }
 
     async text(): Promise<string> {
-        return await this.#uRes.text();
+        return this.#uRes.text();
     }
 }


### PR DESCRIPTION
https://typescript-eslint.io/rules/return-await/

This rule can be auto-fixed and enforces no `await` when returning a promise, except it enforces the opposite if inside a `try` block