### PR TITLE
Turn on "return-await" eslint rule [v3.x]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,9 @@
             "error", {
                 "accessibility": "no-public"
             }
-        ]
+        ],
+        "no-return-await": "off",
+        "@typescript-eslint/return-await": "error"
     },
     "ignorePatterns": [
         "**/*.js",


### PR DESCRIPTION
https://typescript-eslint.io/rules/return-await/

This rule can be auto-fixed and enforces no `await` when returning a promise, except it enforces the opposite if inside a `try` block