### PR TITLE
Fix bug for durable when returning value without a binding set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.0.0-alpha.7",
+    "version": "4.0.0-alpha.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.0.0-alpha.7",
+            "version": "4.0.0-alpha.8",
             "license": "MIT",
             "dependencies": {
                 "long": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.0.0-alpha.7",
+    "version": "4.0.0-alpha.8",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -92,10 +92,12 @@ export class InvocationModel implements coreTypes.InvocationModel {
         const response: RpcInvocationResponse = { invocationId: this.#coreCtx.invocationId };
 
         response.outputData = [];
+        let usedReturnValue = false;
         for (const [name, binding] of Object.entries(this.#bindings)) {
             if (binding.direction === 'out') {
                 if (name === returnBindingKey) {
                     response.returnValue = await this.#convertOutput(binding, result);
+                    usedReturnValue = true;
                 } else {
                     response.outputData.push({
                         name,
@@ -109,7 +111,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
         // to the host, even if no explicit output binding is set. In most cases, this is ignored,
         // but e.g., Durable uses this to pass orchestrator state back to the Durable extension, w/o
         // an explicit output binding. See here for more details: https://github.com/Azure/azure-functions-nodejs-library/pull/25
-        if (!response.returnValue && response.outputData.length == 0 && !isHttpTrigger(this.#triggerType)) {
+        if (!usedReturnValue && !isHttpTrigger(this.#triggerType)) {
             response.returnValue = toRpcTypedData(result);
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.0.0-alpha.7';
+export const version = '4.0.0-alpha.8';
 
 export const returnBindingKey = '$return';


### PR DESCRIPTION
The old logic was based on the value itself and other bindings. The new logic is just "Did we use it yet?"

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/53