### PR TITLE
Add build version to prerelease package drop

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: IsPrerelease
+  type: boolean
+  default: true
+
 pr:
   branches:
     include:
@@ -19,6 +24,9 @@ jobs:
     displayName: 'Install Node.js'
   - script: npm ci
     displayName: 'npm ci'
+  - script: npm run updateVersion -- --buildNumber $(Build.BuildNumber)
+    displayName: 'npm run updateVersion'
+    condition: and(succeeded(), eq(${{ parameters.IsPrerelease }}, true))
   - script: npm run build
     displayName: 'npm run build'
   - script: npm run minify

--- a/scripts/updateVersion.ts
+++ b/scripts/updateVersion.ts
@@ -17,18 +17,24 @@ if (args.validate) {
     validateVersion();
 } else if (args.version) {
     updateVersion(args.version);
+} else if (args.buildNumber) {
+    const currentVersion = validateVersion();
+    const newVersion = currentVersion.includes('alpha')
+        ? `${currentVersion}.${args.buildNumber}`
+        : `${currentVersion}-alpha.${args.buildNumber}`;
+    updateVersion(newVersion);
 } else {
     console.log(`This script can be used to either update the version of the library or validate that the repo is in a valid state with regards to versioning.
 
 Example usage:
 
 npm run updateVersion -- --version 3.3.0
-
+npm run updateVersion -- --buildNumber 20230517.1
 npm run updateVersion -- --validate`);
     throw new Error('Invalid arguments');
 }
 
-function validateVersion() {
+function validateVersion(): string {
     const packageJson = readJSONSync(packageJsonPath);
     const packageJsonVersion = packageJson.version;
 
@@ -46,6 +52,7 @@ function validateVersion() {
         throw new Error(`Versions do not match.`);
     } else {
         console.log('Versions match! 🎉');
+        return packageJsonVersion;
     }
 }
 


### PR DESCRIPTION
Same deal as https://github.com/Azure/azure-functions-nodejs-worker/pull/688. It will be easier to debug the end to end tests if I can see the exact build number version we're testing against