### PR TITLE
Add Hooks support in v4

### DIFF
--- a/src/InvocationContext.ts
+++ b/src/InvocationContext.ts
@@ -10,6 +10,7 @@ import {
     TraceContext,
     TriggerMetadata,
 } from '@azure/functions';
+import { fallbackLogHandler } from './log';
 
 export class InvocationContext implements types.InvocationContext {
     invocationId: string;
@@ -90,28 +91,5 @@ class InvocationContextExtraOutputs implements types.InvocationContextExtraOutpu
     set(outputOrName: types.FunctionOutput | string, value: unknown): void {
         const name = typeof outputOrName === 'string' ? outputOrName : outputOrName.name;
         this.#outputs[name] = value;
-    }
-}
-
-function fallbackLogHandler(level: types.LogLevel, ...args: unknown[]): void {
-    switch (level) {
-        case 'trace':
-            console.trace(...args);
-            break;
-        case 'debug':
-            console.debug(...args);
-            break;
-        case 'information':
-            console.info(...args);
-            break;
-        case 'warning':
-            console.warn(...args);
-            break;
-        case 'critical':
-        case 'error':
-            console.error(...args);
-            break;
-        default:
-            console.log(...args);
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,6 @@ import {
     AppTerminateHandler,
     CosmosDBFunctionOptions,
     CosmosDBTrigger,
-    Disposable,
     EventGridFunctionOptions,
     EventHubFunctionOptions,
     FunctionOptions,
@@ -34,6 +33,7 @@ import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
 import { InvocationModel } from './InvocationModel';
 import { returnBindingKey, version } from './constants';
 import { AppStartContext } from './hooks/AppStartContext';
+import { Disposable } from './hooks/Disposable';
 import { HookContext } from './hooks/HookContext';
 import { PostInvocationContext } from './hooks/PostInvocationContext';
 import { PreInvocationContext } from './hooks/PreInvocationContext';
@@ -321,7 +321,7 @@ export function generic(name: string, options: FunctionOptions): RegisterResult 
 function coreRegisterHook(hookName: string, callback: coreTypes.HookCallback): coreTypes.Disposable {
     const coreApi = tryGetCoreApiLazy();
     if (!coreApi) {
-        console.error(
+        console.warn(
             `WARNING: Skipping call to register ${hookName} hook because the "@azure/functions" package is in test mode.`
         );
         return new Disposable(() => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import * as coreTypes from '@azure/functions-core';
 import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
 import { InvocationModel } from './InvocationModel';
 import { returnBindingKey, version } from './constants';
+import { HookContext } from './hooks/HookContext';
 import { PostInvocationContext } from './hooks/PostInvocationContext';
 import { PreInvocationContext } from './hooks/PreInvocationContext';
 import * as output from './output';
@@ -303,7 +304,7 @@ export function coreRegisterHook(hookName: string, callback: coreTypes.HookCallb
 }
 
 export function onTerminate(handler: AppTerminateHandler): Disposable {
-    return on('appTerminate', handler as HookHandler);
+    return on('appTerminate', handler);
 }
 
 export function onStart(handler: AppStartHandler): Disposable {
@@ -311,7 +312,11 @@ export function onStart(handler: AppStartHandler): Disposable {
 }
 
 export function on(hookName: string, handler: HookHandler): Disposable {
-    return coreRegisterHook(hookName, handler as coreTypes.HookCallback);
+    const coreCallback: coreTypes.HookCallback = (coreContext: coreTypes.HookContext) => {
+        const context = new HookContext(coreContext);
+        return handler(context);
+    };
+    return coreRegisterHook(hookName, coreCallback);
 }
 
 export function onPreInvocation(functions: string[], handler: PreInvocationHandler): Disposable {

--- a/src/app.ts
+++ b/src/app.ts
@@ -328,7 +328,7 @@ export function onPreInvocation(handlerOrOptions: PreInvocationHandler | PreInvo
         typeof handlerOrOptions === 'function' ? [] : handlerOrOptions.filter;
     const coreCallback: coreTypes.PreInvocationCallback = (coreContext: coreTypes.PreInvocationContext) => {
         const invocContext = coreContext.invocationContext as InvocationContext;
-        if (!filter || shouldRun(invocContext, filter)) {
+        if (!filter || shouldRunHook(invocContext, filter)) {
             const preInvocContext = new PreInvocationContext({
                 ...coreContext,
                 functionHandler: coreContext.functionCallback,
@@ -342,9 +342,9 @@ export function onPreInvocation(handlerOrOptions: PreInvocationHandler | PreInvo
     return coreRegisterHook('preInvocation', coreCallback as coreTypes.HookCallback);
 }
 
-function shouldRun(invocationContext: InvocationContext, filter: HookFilter | HookFilter[]): boolean {
+function shouldRunHook(invocationContext: InvocationContext, filter: HookFilter | HookFilter[]): boolean {
     if (Array.isArray(filter)) {
-        return filter.every((f) => shouldRun(invocationContext, f));
+        return filter.every((f) => shouldRunHook(invocationContext, f));
     } else if (typeof filter === 'object') {
         const filters: boolean[] = [];
         if (filter.functionNames) {
@@ -370,7 +370,7 @@ export function onPostInvocation(handlerOrOptions: PostInvocationHandler | PostI
         typeof handlerOrOptions === 'function' ? [] : handlerOrOptions.filter;
     const coreCallback: coreTypes.PostInvocationCallback = (coreContext: coreTypes.PostInvocationContext) => {
         const invocContext: InvocationContext = coreContext.invocationContext as InvocationContext;
-        if (!filter || shouldRun(invocContext, filter)) {
+        if (!filter || shouldRunHook(invocContext, filter)) {
             const postInvocContext = new PostInvocationContext({
                 ...coreContext,
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/app.ts
+++ b/src/app.ts
@@ -319,6 +319,7 @@ export function onPreInvocation(functions: string[], handler: PreInvocationHandl
         const invocContext = coreContext.invocationContext as InvocationContext;
         if (functions.includes(invocContext.functionName) || functions.length === 0) {
             const preInvocContext = new PreInvocationContext({
+                ...coreContext,
                 functionHandler: coreContext.functionCallback,
                 args: coreContext.inputs,
                 invocationContext: invocContext,
@@ -331,20 +332,21 @@ export function onPreInvocation(functions: string[], handler: PreInvocationHandl
 }
 
 export function onPostInvocation(functions: string[], handler: PostInvocationHandler): coreTypes.Disposable {
-    const newCallback: coreTypes.PostInvocationCallback = (context: coreTypes.PostInvocationContext) => {
-        const invocContext: InvocationContext = context.invocationContext as InvocationContext;
+    const coreCallback: coreTypes.PostInvocationCallback = (coreContext: coreTypes.PostInvocationContext) => {
+        const invocContext: InvocationContext = coreContext.invocationContext as InvocationContext;
         if (functions.includes(invocContext.functionName) || functions.length === 0) {
-            const newContext = new PostInvocationContext({
+            const postInvocContext = new PostInvocationContext({
+                ...coreContext,
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                result: context.result,
+                result: coreContext.result,
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                errorResult: context.error,
-                args: context.inputs,
+                errorResult: coreContext.error,
+                args: coreContext.inputs,
                 invocationContext: invocContext,
-                coreContext: context,
+                coreContext,
             });
-            return handler(newContext);
+            return handler(postInvocContext);
         }
     };
-    return coreRegisterHook('postInvocation', newCallback as coreTypes.HookCallback);
+    return coreRegisterHook('postInvocation', coreCallback as coreTypes.HookCallback);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -240,7 +240,7 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): Regist
             startFromTime: options.startFromTime,
         });
     }
-    generic(name, {
+    return generic(name, {
         trigger: cosmosTrigger,
         ...options,
     });

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,6 @@
 
 import {
     AppStartHandler,
-    AppTerminateContext,
     AppTerminateHandler,
     CosmosDBFunctionOptions,
     CosmosDBTrigger,
@@ -33,6 +32,7 @@ import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
 import { InvocationModel } from './InvocationModel';
 import { returnBindingKey, version } from './constants';
 import { AppStartContext } from './hooks/AppStartContext';
+import { AppTerminateContext } from './hooks/AppTerminateContext';
 import { Disposable } from './hooks/Disposable';
 import { HookContext } from './hooks/HookContext';
 import { PostInvocationContext } from './hooks/PostInvocationContext';

--- a/src/app.ts
+++ b/src/app.ts
@@ -341,11 +341,21 @@ export function onStart(handler: AppStartHandler): Disposable {
 }
 
 export function on(hookName: string, handler: HookHandler): Disposable {
-    const coreCallback: coreTypes.HookCallback = (coreContext: coreTypes.HookContext) => {
-        const context = new HookContext(coreContext);
-        return handler(context);
-    };
-    return coreRegisterHook(hookName, coreCallback);
+    switch (hookName) {
+        case 'appStart':
+            return onStart(handler as AppStartHandler);
+        case 'preInvocation':
+            return onPreInvocation(handler as PreInvocationHandler);
+        case 'postInvocation':
+            return onPostInvocation(handler as PostInvocationHandler);
+        default: {
+            const coreCallback: coreTypes.HookCallback = (coreContext: coreTypes.HookContext) => {
+                const context = new HookContext(coreContext);
+                return handler(context);
+            };
+            return coreRegisterHook(hookName, coreCallback);
+        }
+    }
 }
 
 export function onPreInvocation(handlerOrOptions: PreInvocationHandler | PreInvocationOptions): Disposable {

--- a/src/app.ts
+++ b/src/app.ts
@@ -345,6 +345,18 @@ export function onPreInvocation(handlerOrOptions: PreInvocationHandler | PreInvo
 function shouldRun(invocationContext: InvocationContext, filter: HookFilter | HookFilter[]): boolean {
     if (Array.isArray(filter)) {
         return filter.every((f) => shouldRun(invocationContext, f));
+    } else if (typeof filter === 'object') {
+        const filters: boolean[] = [];
+        if (filter.functionNames) {
+            filters.push(filter.functionNames.includes(invocationContext.functionName));
+        }
+        if (filter.triggerTypes) {
+            filters.push(filter.triggerTypes.includes(invocationContext.options.trigger.type));
+        }
+        if (filter.invocationIds) {
+            filters.push(filter.invocationIds.includes(invocationContext.invocationId));
+        }
+        return filters.every((f) => f);
     } else if (typeof filter === 'string') {
         return invocationContext.functionName === filter;
     } else {

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,7 @@ import * as coreTypes from '@azure/functions-core';
 import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
 import { InvocationModel } from './InvocationModel';
 import { returnBindingKey, version } from './constants';
+import { AppStartContext } from './hooks/AppStartContext';
 import { HookContext } from './hooks/HookContext';
 import { PostInvocationContext } from './hooks/PostInvocationContext';
 import { PreInvocationContext } from './hooks/PreInvocationContext';
@@ -332,7 +333,11 @@ export function onTerminate(handler: AppTerminateHandler): Disposable {
 }
 
 export function onStart(handler: AppStartHandler): Disposable {
-    return on('appStart', handler as HookHandler);
+    const coreHandler: coreTypes.AppStartCallback = (coreContext: coreTypes.AppStartContext) => {
+        const context = new AppStartContext(coreContext);
+        return handler(context);
+    };
+    return coreRegisterHook('appStart', coreHandler as coreTypes.HookCallback);
 }
 
 export function on(hookName: string, handler: HookHandler): Disposable {

--- a/src/app.ts
+++ b/src/app.ts
@@ -288,15 +288,23 @@ export function generic(name: string, options: FunctionOptions): void {
 }
 
 export function onTerminate(callback: AppTerminateCallback): Disposable {
-    return coreTypes.registerHook('appTerminate', callback);
+    return on('appTerminate', callback as HookCallback);
 }
 
 export function onStart(callback: AppStartCallback): Disposable {
-    return coreTypes.registerHook('appStart', callback);
+    return on('appStart', callback as HookCallback);
 }
 
 export function on(hookName: string, callback: HookCallback): Disposable {
-    return coreTypes.registerHook(hookName, callback);
+    const coreApi = tryGetCoreApiLazy();
+    if (!coreApi) {
+        console.warn(
+            `WARNING: Skipping call to register ${hookName} hook because the "@azure/functions" package is in test mode.`
+        );
+        throw new Error(`Could not register ${hookName} hooks because the "@azure/functions" package is in test mode.`);
+    } else {
+        return coreApi.registerHook(hookName, callback);
+    }
 }
 
 export function onPreInvocation(functions: string[], callback: PreInvocationCallback): coreTypes.Disposable {
@@ -311,7 +319,7 @@ export function onPreInvocation(functions: string[], callback: PreInvocationCall
             return callback(newContext);
         }
     };
-    return coreTypes.registerHook('preInvocation', newCallback);
+    return on('preInvocation', newCallback as HookCallback);
 }
 
 export function onPostInvocation(
@@ -329,5 +337,5 @@ export function onPostInvocation(
             return callback(newContext);
         }
     };
-    return coreTypes.registerHook('postInvocation', newCallback);
+    return on('postInvocation', newCallback as HookCallback);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
     HttpHandler,
     HttpMethod,
     HttpMethodFunctionOptions,
+    InvocationContext,
     ServiceBusQueueFunctionOptions,
     ServiceBusTopicFunctionOptions,
     StorageBlobFunctionOptions,
@@ -279,4 +280,39 @@ export function generic(name: string, options: FunctionOptions): void {
     } else {
         coreApi.registerFunction({ name, bindings }, <FunctionCallback>options.handler);
     }
+}
+
+export function onTerminate(callback: coreTypes.AppTerminateCallback): coreTypes.Disposable {
+    return coreTypes.registerHook('appTerminate', callback);
+}
+
+export function onStart(callback: coreTypes.AppStartCallback): coreTypes.Disposable {
+    return coreTypes.registerHook('appStart', callback);
+}
+
+export function on(hookName: string, callback: coreTypes.HookCallback): coreTypes.Disposable {
+    return coreTypes.registerHook(hookName, callback);
+}
+
+export function onPreInvocation(functions: string[], callback: coreTypes.PreInvocationCallback): coreTypes.Disposable {
+    const newCallback: coreTypes.PreInvocationCallback = (context: coreTypes.PreInvocationContext) => {
+        const invocContext = context.invocationContext as InvocationContext;
+        if (functions.includes(invocContext.functionName) || functions.length === 0) {
+            return callback(context);
+        }
+    };
+    return coreTypes.registerHook('preInvocation', newCallback);
+}
+
+export function onPostInvocation(
+    functions: string[],
+    callback: coreTypes.PostInvocationCallback
+): coreTypes.Disposable {
+    const newCallback: coreTypes.PostInvocationCallback = (context: coreTypes.PostInvocationContext) => {
+        const invocContext: InvocationContext = context.invocationContext as InvocationContext;
+        if (functions.includes(invocContext.functionName) || functions.length === 0) {
+            return callback(context);
+        }
+    };
+    return coreTypes.registerHook('postInvocation', newCallback);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -379,6 +379,7 @@ export function onPreInvocation(handlerOrOptions: PreInvocationHandler | PreInvo
         const invocationContext = coreContext.invocationContext as InvocationContext;
         if (!isDefined(filter) || shouldRunHook(invocationContext, filter)) {
             const preInvocContext = new PreInvocationContext({
+                // spreading here is necessary to pass hookData and appHookData objects
                 ...coreContext,
                 functionHandler: coreContext.functionCallback,
                 args: coreContext.inputs,
@@ -400,6 +401,7 @@ export function onPostInvocation(handlerOrOptions: PostInvocationHandler | PostI
         const invocationContext = coreContext.invocationContext as InvocationContext;
         if (!isDefined(filter) || shouldRunHook(invocationContext, filter)) {
             const postInvocContext = new PostInvocationContext({
+                // spreading here is necessary to pass hookData and appHookData objects
                 ...coreContext,
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 result: coreContext.result,

--- a/src/hooks/AppStartContext.ts
+++ b/src/hooks/AppStartContext.ts
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { AppStartContextInit } from '@azure/functions';
+import { HookContext } from './HookContext';
+
+export class AppStartContext extends HookContext implements types.AppStartContext {
+    functionAppDirectory: string;
+
+    constructor(init?: AppStartContextInit) {
+        super(init);
+        init = init || {};
+        this.functionAppDirectory = init.functionAppDirectory || 'unknown';
+    }
+}

--- a/src/hooks/AppTerminateContext.ts
+++ b/src/hooks/AppTerminateContext.ts
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { AppTerminateContextInit } from '@azure/functions';
+import { HookContext } from './HookContext';
+
+export class AppTerminateContext extends HookContext implements types.AppTerminateContext {
+    constructor(init?: AppTerminateContextInit) {
+        super(init);
+    }
+}

--- a/src/hooks/Disposable.ts
+++ b/src/hooks/Disposable.ts
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Based off of the Node worker
+ * https://github.com/Azure/azure-functions-nodejs-worker/blob/bf28d9c5ad4ed22c5e42c082471d16108abee140/src/Disposable.ts
+ */
+export class Disposable {
+    static from(...inDisposables: { dispose(): any }[]): Disposable {
+        let disposables: ReadonlyArray<{ dispose(): any }> | undefined = inDisposables;
+        return new Disposable(function () {
+            if (disposables) {
+                for (const disposable of disposables) {
+                    if (disposable && typeof disposable.dispose === 'function') {
+                        disposable.dispose();
+                    }
+                }
+                disposables = undefined;
+            }
+        });
+    }
+
+    #callOnDispose?: () => any;
+
+    constructor(callOnDispose: () => any) {
+        this.#callOnDispose = callOnDispose;
+    }
+
+    dispose(): any {
+        if (this.#callOnDispose instanceof Function) {
+            this.#callOnDispose();
+            this.#callOnDispose = undefined;
+        }
+    }
+}

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -3,14 +3,29 @@
 
 import * as types from '@azure/functions';
 import { HookContextInit, HookData } from '@azure/functions';
+import { ReadOnlyError } from '../errors';
 
 export abstract class HookContext implements types.HookContext {
-    readonly hookData: HookData;
-    readonly appHookData: HookData;
+    #hookData: HookData;
+    #appHookData: HookData;
 
     constructor(init?: HookContextInit) {
         init = init || {};
-        this.hookData = init.hookData || {};
-        this.appHookData = init.appHookData || {};
+        this.#hookData = init.hookData || {};
+        this.#appHookData = init.appHookData || {};
+    }
+
+    get hookData(): HookData {
+        return this.#hookData;
+    }
+    set hookData(_value: HookData) {
+        throw new ReadOnlyError('hookData');
+    }
+
+    get appHookData(): HookData {
+        return this.#appHookData;
+    }
+    set appHookData(_value: HookData) {
+        throw new ReadOnlyError('appHookData');
     }
 }

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -18,6 +18,7 @@ export abstract class HookContext implements types.HookContext {
     get hookData(): HookData {
         return this.#hookData;
     }
+
     set hookData(_value: HookData) {
         throw new ReadOnlyError('hookData');
     }
@@ -25,6 +26,7 @@ export abstract class HookContext implements types.HookContext {
     get appHookData(): HookData {
         return this.#appHookData;
     }
+
     set appHookData(_value: HookData) {
         throw new ReadOnlyError('appHookData');
     }

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -10,6 +10,9 @@ export class HookContext implements types.HookContext {
 
     constructor(init?: HookContextInit) {
         init = init || {};
+
+        // It's important to use the original objects passed in init (no copies or clones)
+        // because modifications to these objects are persisted by the worker
         this.#hookData = init.hookData || {};
         this.#appHookData = init.appHookData || {};
     }

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -12,6 +12,7 @@ export class HookContext implements types.HookContext {
         init = init || {};
         this.#hookData = init.hookData || {};
         this.#appHookData = init.appHookData || {};
+        Object.assign(this, init);
     }
 
     get(propertyName: string): unknown {

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -3,9 +3,8 @@
 
 import * as types from '@azure/functions';
 import { HookContextInit, HookData } from '@azure/functions';
-import { ReadOnlyError } from '../errors';
 
-export abstract class HookContext implements types.HookContext {
+export class HookContext implements types.HookContext {
     #hookData: HookData;
     #appHookData: HookData;
 
@@ -15,19 +14,19 @@ export abstract class HookContext implements types.HookContext {
         this.#appHookData = init.appHookData || {};
     }
 
-    get hookData(): HookData {
-        return this.#hookData;
+    get(propertyName: string): unknown {
+        return this.#hookData[propertyName];
     }
 
-    set hookData(_value: HookData) {
-        throw new ReadOnlyError('hookData');
+    set(propertyName: string, value: unknown): void {
+        this.#hookData[propertyName] = value;
     }
 
-    get appHookData(): HookData {
-        return this.#appHookData;
+    getGlobal(propertyName: string): unknown {
+        return this.#appHookData[propertyName];
     }
 
-    set appHookData(_value: HookData) {
-        throw new ReadOnlyError('appHookData');
+    setGlobal(propertyName: string, value: unknown): void {
+        this.#appHookData[propertyName] = value;
     }
 }

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -12,7 +12,6 @@ export class HookContext implements types.HookContext {
         init = init || {};
         this.#hookData = init.hookData || {};
         this.#appHookData = init.appHookData || {};
-        Object.assign(this, init);
     }
 
     get(propertyName: string): unknown {

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { HookContextInit, HookData } from '@azure/functions';
+
+export abstract class HookContext implements types.HookContext {
+    readonly hookData: HookData;
+    readonly appHookData: HookData;
+
+    constructor(init?: HookContextInit) {
+        init = init || {};
+        this.hookData = init.hookData || {};
+        this.appHookData = init.appHookData || {};
+    }
+}

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -9,14 +9,14 @@ import { logHandlerFromContext } from '../log';
 import { HookContext } from './HookContext';
 
 export abstract class InvocationHookContext extends HookContext implements types.InvocationHookContext {
-    #userLogHandler: LogHandler;
+    #logHandler: LogHandler;
     #invocationContext: types.InvocationContext;
 
     constructor(init?: types.InvocationHookContextInit) {
         super(init);
         init = init || {};
         this.#invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
-        this.#userLogHandler = init.logHandler || logHandlerFromContext(this.invocationContext);
+        this.#logHandler = init.logHandler || logHandlerFromContext(this.invocationContext);
     }
 
     get invocationContext(): types.InvocationContext {
@@ -28,26 +28,26 @@ export abstract class InvocationHookContext extends HookContext implements types
     }
 
     log(...args: unknown[]): void {
-        this.#userLogHandler('information', ...args);
+        this.#logHandler('information', ...args);
     }
 
     trace(...args: unknown[]): void {
-        this.#userLogHandler('trace', ...args);
+        this.#logHandler('trace', ...args);
     }
 
     debug(...args: unknown[]): void {
-        this.#userLogHandler('debug', ...args);
+        this.#logHandler('debug', ...args);
     }
 
     info(...args: unknown[]): void {
-        this.#userLogHandler('information', ...args);
+        this.#logHandler('information', ...args);
     }
 
     warn(...args: unknown[]): void {
-        this.#userLogHandler('warning', ...args);
+        this.#logHandler('warning', ...args);
     }
 
     error(...args: unknown[]): void {
-        this.#userLogHandler('error', ...args);
+        this.#logHandler('error', ...args);
     }
 }

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { HookData, InvocationContext, LogHandler } from '@azure/functions';
+import { logHandlerFromContext } from '../log';
+import { HookContext } from './HookContext';
+
+export abstract class InvocationHookContext extends HookContext implements types.InvocationHookContext {
+    readonly hookData: HookData;
+    readonly appHookData: HookData;
+    readonly invocationContext: InvocationContext;
+    args: any[];
+    #userLogHandler: LogHandler;
+
+    constructor(init?: types.PreInvocationContextInit) {
+        super(init);
+        init = init || {};
+        this.hookData = init.hookData || {};
+        this.appHookData = init.appHookData || {};
+        this.args = init.args || [];
+        this.invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
+        this.#userLogHandler = init.logHandler || logHandlerFromContext(this.invocationContext);
+    }
+
+    log(...args: unknown[]): void {
+        this.#userLogHandler('information', ...args);
+    }
+
+    trace(...args: unknown[]): void {
+        this.#userLogHandler('trace', ...args);
+    }
+
+    debug(...args: unknown[]): void {
+        this.#userLogHandler('debug', ...args);
+    }
+
+    info(...args: unknown[]): void {
+        this.#userLogHandler('information', ...args);
+    }
+
+    warn(...args: unknown[]): void {
+        this.#userLogHandler('warning', ...args);
+    }
+
+    error(...args: unknown[]): void {
+        this.#userLogHandler('error', ...args);
+    }
+}

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -9,14 +9,12 @@ import { logHandlerFromContext } from '../log';
 import { HookContext } from './HookContext';
 
 export abstract class InvocationHookContext extends HookContext implements types.InvocationHookContext {
-    args: any[];
     #userLogHandler: LogHandler;
     #invocationContext: types.InvocationContext;
 
-    constructor(init?: types.PreInvocationContextInit) {
+    constructor(init?: types.InvocationHookContextInit) {
         super(init);
         init = init || {};
-        this.args = init.args || [];
         this.#invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
         this.#userLogHandler = init.logHandler || logHandlerFromContext(this.invocationContext);
     }

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -16,8 +16,6 @@ export abstract class InvocationHookContext extends HookContext implements types
     constructor(init?: types.PreInvocationContextInit) {
         super(init);
         init = init || {};
-        this.hookData = init.hookData || {};
-        this.appHookData = init.appHookData || {};
         this.args = init.args || [];
         this.#invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
         this.#userLogHandler = init.logHandler || logHandlerFromContext(this.invocationContext);

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 import * as types from '@azure/functions';
-import { HookData, InvocationContext, LogHandler } from '@azure/functions';
+import { HookData, LogHandler } from '@azure/functions';
+import { InvocationContext } from '../InvocationContext';
 import { logHandlerFromContext } from '../log';
 import { HookContext } from './HookContext';
 
 export abstract class InvocationHookContext extends HookContext implements types.InvocationHookContext {
     readonly hookData: HookData;
     readonly appHookData: HookData;
-    readonly invocationContext: InvocationContext;
+    readonly invocationContext: types.InvocationContext;
     args: any[];
     #userLogHandler: LogHandler;
 

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 import * as types from '@azure/functions';
-import { HookData, LogHandler } from '@azure/functions';
+import { LogHandler } from '@azure/functions';
 import { InvocationContext } from '../InvocationContext';
+import { ReadOnlyError } from '../errors';
 import { logHandlerFromContext } from '../log';
 import { HookContext } from './HookContext';
 
 export abstract class InvocationHookContext extends HookContext implements types.InvocationHookContext {
-    readonly hookData: HookData;
-    readonly appHookData: HookData;
-    readonly invocationContext: types.InvocationContext;
     args: any[];
     #userLogHandler: LogHandler;
+    #invocationContext: types.InvocationContext;
 
     constructor(init?: types.PreInvocationContextInit) {
         super(init);
@@ -20,8 +19,16 @@ export abstract class InvocationHookContext extends HookContext implements types
         this.hookData = init.hookData || {};
         this.appHookData = init.appHookData || {};
         this.args = init.args || [];
-        this.invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
+        this.#invocationContext = init.invocationContext || new InvocationContext({ logHandler: init.logHandler });
         this.#userLogHandler = init.logHandler || logHandlerFromContext(this.invocationContext);
+    }
+
+    get invocationContext(): types.InvocationContext {
+        return this.#invocationContext;
+    }
+
+    set invocationContext(_value: types.InvocationContext) {
+        throw new ReadOnlyError('invocationContext');
     }
 
     log(...args: unknown[]): void {

--- a/src/hooks/PostInvocationContext.ts
+++ b/src/hooks/PostInvocationContext.ts
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { InvocationHookContext } from './InvocationHookContext';
+
+export class PostInvocationContext extends InvocationHookContext implements types.PostInvocationContext {
+    result: any;
+    error: any;
+
+    constructor(init?: types.PostInvocationContextInit) {
+        init = init || {};
+        super(init);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        this.result = typeof init.result === 'undefined' ? null : init.result;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        this.error = typeof init.error === 'undefined' ? null : init.error;
+    }
+}

--- a/src/hooks/PostInvocationContext.ts
+++ b/src/hooks/PostInvocationContext.ts
@@ -30,6 +30,8 @@ export class PostInvocationContext extends InvocationHookContext implements type
     }
 
     set args(value: any[]) {
+        // it's important to use the core context inputs
+        // since changes to this array are persisted by the worker
         this.#coreCtx.inputs = value;
     }
 
@@ -39,6 +41,8 @@ export class PostInvocationContext extends InvocationHookContext implements type
     }
 
     set result(value: any) {
+        // it's important to use the core context result
+        // since changes to this value are persisted by the worker
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.#coreCtx.result = value;
     }
@@ -49,6 +53,8 @@ export class PostInvocationContext extends InvocationHookContext implements type
     }
 
     set errorResult(value: any) {
+        // it's important to use the core context result
+        // since changes to this value are persisted by the worker
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.#coreCtx.error = value;
     }

--- a/src/hooks/PostInvocationContext.ts
+++ b/src/hooks/PostInvocationContext.ts
@@ -2,19 +2,54 @@
 // Licensed under the MIT License.
 
 import * as types from '@azure/functions';
+import { PostInvocationCoreContext } from '@azure/functions';
 import { InvocationHookContext } from './InvocationHookContext';
 
 export class PostInvocationContext extends InvocationHookContext implements types.PostInvocationContext {
-    result: any;
-    errorResult: any;
+    #coreCtx: PostInvocationCoreContext;
 
     constructor(init?: types.PostInvocationContextInit) {
-        init = init || {};
         super(init);
+        init = init || {};
+        if (!init.coreContext) {
+            init.coreContext = {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                result: typeof init.result === 'undefined' ? null : init.errorResult,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                error: typeof init.errorResult === 'undefined' ? null : init.errorResult,
+                inputs: init.args || [],
+            };
+        }
 
+        this.#coreCtx = init.coreContext;
+    }
+
+    get args(): any[] {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.#coreCtx.inputs;
+    }
+
+    set args(value: any[]) {
+        this.#coreCtx.inputs = value;
+    }
+
+    get result(): any {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.#coreCtx.result;
+    }
+
+    set result(value: any) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.result = typeof init.result === 'undefined' ? null : init.result;
+        this.#coreCtx.result = value;
+    }
+
+    get errorResult(): any {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.#coreCtx.error;
+    }
+
+    set errorResult(value: any) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.errorResult = typeof init.errorResult === 'undefined' ? null : init.errorResult;
+        this.#coreCtx.error = value;
     }
 }

--- a/src/hooks/PostInvocationContext.ts
+++ b/src/hooks/PostInvocationContext.ts
@@ -6,7 +6,7 @@ import { InvocationHookContext } from './InvocationHookContext';
 
 export class PostInvocationContext extends InvocationHookContext implements types.PostInvocationContext {
     result: any;
-    error: any;
+    errorResult: any;
 
     constructor(init?: types.PostInvocationContextInit) {
         init = init || {};
@@ -15,6 +15,6 @@ export class PostInvocationContext extends InvocationHookContext implements type
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.result = typeof init.result === 'undefined' ? null : init.result;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.error = typeof init.error === 'undefined' ? null : init.error;
+        this.errorResult = typeof init.errorResult === 'undefined' ? null : init.errorResult;
     }
 }

--- a/src/hooks/PreInvocationContext.ts
+++ b/src/hooks/PreInvocationContext.ts
@@ -31,6 +31,8 @@ export class PreInvocationContext extends InvocationHookContext implements types
     }
 
     set functionHandler(value: FunctionHandler) {
+        // it's important to use the core context functionCallback
+        // since changes to this value are persisted by the worker
         this.#coreCtx.functionCallback = value;
     }
 
@@ -40,6 +42,8 @@ export class PreInvocationContext extends InvocationHookContext implements types
     }
 
     set args(value: any[]) {
+        // it's important to use the core context inputs
+        // since changes to this array are persisted by the worker
         this.#coreCtx.inputs = value;
     }
 

--- a/src/hooks/PreInvocationContext.ts
+++ b/src/hooks/PreInvocationContext.ts
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { FunctionHandler, PreInvocationContextInit } from '@azure/functions';
+import { InvocationHookContext } from './InvocationHookContext';
+
+export class PreInvocationContext extends InvocationHookContext implements types.PreInvocationContext {
+    functionCallback: FunctionHandler;
+
+    constructor(init?: PreInvocationContextInit) {
+        init = init || {};
+        super(init);
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        this.functionCallback = init.functionCallback || (() => {});
+    }
+}

--- a/src/hooks/PreInvocationContext.ts
+++ b/src/hooks/PreInvocationContext.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 import * as types from '@azure/functions';
-import { FunctionHandler, PreInvocationContextInit, PreInvocationCoreContext } from '@azure/functions';
+import {
+    FunctionHandler,
+    InvocationContext,
+    PreInvocationContextInit,
+    PreInvocationCoreContext,
+} from '@azure/functions';
 import { InvocationHookContext } from './InvocationHookContext';
 
 export class PreInvocationContext extends InvocationHookContext implements types.PreInvocationContext {
@@ -36,5 +41,16 @@ export class PreInvocationContext extends InvocationHookContext implements types
 
     set args(value: any[]) {
         this.#coreCtx.inputs = value;
+    }
+
+    abort(): void {
+        this.invocationContext.warn(
+            `Aborting execution of ${this.invocationContext.functionName}` +
+                ` with invocation ID ${this.invocationContext.invocationId}`
+        );
+
+        this.#coreCtx.functionCallback = (_trigger, context: InvocationContext) => {
+            context.log(`Invocation ${context.invocationId} of ${context.functionName} has been aborted`);
+        };
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+export { InvocationContext } from './InvocationContext';
 export * as app from './app';
 export { HttpRequest } from './http/HttpRequest';
 export { HttpResponse } from './http/HttpResponse';
 export * as input from './input';
-export { InvocationContext } from './InvocationContext';
 export * as output from './output';
 export * as trigger from './trigger';

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InvocationContext, LogHandler, LogLevel } from '@azure/functions';
+
+export function fallbackLogHandler(level: LogLevel, ...args: unknown[]): void {
+    switch (level) {
+        case 'trace':
+            console.trace(...args);
+            break;
+        case 'debug':
+            console.debug(...args);
+            break;
+        case 'information':
+            console.info(...args);
+            break;
+        case 'warning':
+            console.warn(...args);
+            break;
+        case 'critical':
+        case 'error':
+            console.error(...args);
+            break;
+        default:
+            console.log(...args);
+    }
+}
+
+export function logHandlerFromContext(invocationContext: InvocationContext): LogHandler {
+    return (level: LogLevel, ...args: unknown[]): void => {
+        switch (level) {
+            case 'information':
+                return invocationContext.log(...args);
+            case 'trace':
+                return invocationContext.trace(...args);
+            case 'debug':
+                return invocationContext.debug(...args);
+            case 'warning':
+                return invocationContext.warn(...args);
+            case 'critical':
+            case 'error':
+                return invocationContext.error(...args);
+            default:
+                return invocationContext.log(...args);
+        }
+    };
+}

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -10,7 +10,9 @@ import {
     Disposable,
     HookHandler,
     PostInvocationHandler,
+    PostInvocationOptions,
     PreInvocationHandler,
+    PreInvocationOptions,
 } from './hooks';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
 import { FunctionOptions } from './index';
@@ -161,8 +163,12 @@ export function generic(name: string, options: FunctionOptions): void;
 
 export function onTerminate(handler: AppTerminateHandler): Disposable;
 export function onStart(handler: AppStartHandler): Disposable;
-export function onPreInvocation(functions: string[], handler: PreInvocationHandler): Disposable;
-export function onPostInvocation(functions: string[], handler: PostInvocationHandler): Disposable;
+
+export function onPreInvocation(handler: PreInvocationHandler): Disposable;
+export function onPreInvocation(options: PreInvocationOptions): Disposable;
+
+export function onPostInvocation(handler: PostInvocationHandler): Disposable;
+export function onPostInvocation(options: PostInvocationOptions): Disposable;
 
 export function on(hookName: 'appStart', handler: AppStartHandler): Disposable;
 export function on(hookName: 'appTerminate', handler: AppTerminateHandler): Disposable;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -163,4 +163,9 @@ export function onTerminate(callback: AppTerminateCallback): Disposable;
 export function onStart(callback: AppStartCallback): Disposable;
 export function onPreInvocation(functions: string[], callback: PreInvocationCallback): Disposable;
 export function onPostInvocation(functions: string[], callback: PostInvocationCallback): Disposable;
+
+export function on(hookName: 'appStart', callback: AppStartCallback): Disposable;
+export function on(hookName: 'appTerminate', callback: AppTerminateCallback): Disposable;
+export function on(hookName: 'preInvocation', callback: PreInvocationCallback): Disposable;
+export function on(hookName: 'postInvocation', callback: PostInvocationCallback): Disposable;
 export function on(hookName: string, callback: HookCallback): Disposable;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,19 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-    AppStartCallback,
-    AppTerminateCallback,
-    Disposable,
-    HookCallback,
-    PostInvocationCallback,
-    PreInvocationCallback,
-} from '@azure/functions-core';
 import { CosmosDBFunctionOptions } from './cosmosDB';
 import { EventGridFunctionOptions } from './eventGrid';
 import { EventHubFunctionOptions } from './eventHub';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
-import { FunctionOptions } from './index';
+import {
+    AppStartCallback,
+    AppTerminateCallback,
+    Disposable,
+    FunctionOptions,
+    HookCallback,
+    PostInvocationCallback,
+    PreInvocationCallback,
+} from './index';
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -161,17 +161,68 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): Regist
  */
 export function generic(name: string, options: FunctionOptions): RegisterResult;
 
-export function onTerminate(handler: AppTerminateHandler): Disposable;
-export function onStart(handler: AppStartHandler): Disposable;
-
-export function onPreInvocation(handler: PreInvocationHandler): Disposable;
-export function onPreInvocation(options: PreInvocationOptions): Disposable;
-
-export function onPostInvocation(handler: PostInvocationHandler): Disposable;
-export function onPostInvocation(options: PostInvocationOptions): Disposable;
-
+/**
+ * Registers a hook for the `hookName` event with the provided `handler`
+ *
+ * @param hookName the name of the event to register the hook for
+ * @param handler the hook handler for the event
+ *
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
 export function on(hookName: 'appStart', handler: AppStartHandler): Disposable;
 export function on(hookName: 'appTerminate', handler: AppTerminateHandler): Disposable;
 export function on(hookName: 'preInvocation', handler: PreInvocationHandler): Disposable;
 export function on(hookName: 'postInvocation', handler: PostInvocationHandler): Disposable;
 export function on(hookName: string, handler: HookHandler): Disposable;
+
+/**
+ * Register a hook on the `appStart` event, executed at the start of your application
+ *
+ * @param handler the handler for the event
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onStart(handler: AppStartHandler): Disposable;
+
+/**
+ * Register a hook on the `appTerminate` event, executed during graceful shutdown of your application
+ * This hook will not be executed if your application is terminated forcefully
+ * Please note that all `appTerminate` hooks must finish execution in 10 seconds or less, or they will be terminated.
+ 
+ * @param handler the handler for the event
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onTerminate(handler: AppTerminateHandler): Disposable;
+
+/**
+ * Register a hook to be run right _before_ a function is invoked.
+ * This hook will be executed for all functions in your app.
+ *
+ * @param handler the handler for the event
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onPreInvocation(handler: PreInvocationHandler): Disposable;
+/**
+ * Register a hook to be run right _before_ a function is invoked.
+ * The options object can be used to customize when this hook is run.
+ *
+ * @param options Object specifying the hook handler and any filters to apply to the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onPreInvocation(options: PreInvocationOptions): Disposable;
+
+/**
+ * Register a hook to be run right _after_ a function is invoked.
+ * This hook will be executed for all functions in your app.
+ *
+ * @param handler the handler for the event
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onPostInvocation(handler: PostInvocationHandler): Disposable;
+/**
+ * Register a hook to be run right _after_ a function is invoked.
+ * The options object can be used to customize when this hook is run.
+ *
+ * @param options Object specifying the hook handler and any filters to apply to the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function onPostInvocation(options: PostInvocationOptions): Disposable;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -4,16 +4,16 @@
 import { CosmosDBFunctionOptions } from './cosmosDB';
 import { EventGridFunctionOptions } from './eventGrid';
 import { EventHubFunctionOptions } from './eventHub';
-import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
 import {
-    AppStartCallback,
-    AppTerminateCallback,
+    AppStartHandler,
+    AppTerminateHandler,
     Disposable,
-    FunctionOptions,
-    HookCallback,
-    PostInvocationCallback,
-    PreInvocationCallback,
-} from './index';
+    HookHandler,
+    PostInvocationHandler,
+    PreInvocationHandler,
+} from './hooks';
+import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
+import { FunctionOptions } from './index';
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';
@@ -159,13 +159,13 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
  */
 export function generic(name: string, options: FunctionOptions): void;
 
-export function onTerminate(callback: AppTerminateCallback): Disposable;
-export function onStart(callback: AppStartCallback): Disposable;
-export function onPreInvocation(functions: string[], callback: PreInvocationCallback): Disposable;
-export function onPostInvocation(functions: string[], callback: PostInvocationCallback): Disposable;
+export function onTerminate(handler: AppTerminateHandler): Disposable;
+export function onStart(handler: AppStartHandler): Disposable;
+export function onPreInvocation(functions: string[], handler: PreInvocationHandler): Disposable;
+export function onPostInvocation(functions: string[], handler: PostInvocationHandler): Disposable;
 
-export function on(hookName: 'appStart', callback: AppStartCallback): Disposable;
-export function on(hookName: 'appTerminate', callback: AppTerminateCallback): Disposable;
-export function on(hookName: 'preInvocation', callback: PreInvocationCallback): Disposable;
-export function on(hookName: 'postInvocation', callback: PostInvocationCallback): Disposable;
-export function on(hookName: string, callback: HookCallback): Disposable;
+export function on(hookName: 'appStart', handler: AppStartHandler): Disposable;
+export function on(hookName: 'appTerminate', handler: AppTerminateHandler): Disposable;
+export function on(hookName: 'preInvocation', handler: PreInvocationHandler): Disposable;
+export function on(hookName: 'postInvocation', handler: PostInvocationHandler): Disposable;
+export function on(hookName: string, handler: HookHandler): Disposable;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,6 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import {
+    AppStartCallback,
+    AppTerminateCallback,
+    Disposable,
+    HookCallback,
+    PostInvocationCallback,
+    PreInvocationCallback,
+} from '@azure/functions-core';
 import { CosmosDBFunctionOptions } from './cosmosDB';
 import { EventGridFunctionOptions } from './eventGrid';
 import { EventHubFunctionOptions } from './eventHub';
@@ -150,3 +158,9 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function generic(name: string, options: FunctionOptions): void;
+
+export function onTerminate(callback: AppTerminateCallback): Disposable;
+export function onStart(callback: AppStartCallback): Disposable;
+export function onPreInvocation(functions: string[], callback: PreInvocationCallback): Disposable;
+export function onPostInvocation(functions: string[], callback: PostInvocationCallback): Disposable;
+export function on(hookName: string, callback: HookCallback): Disposable;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -15,7 +15,7 @@ import {
     PreInvocationOptions,
 } from './hooks';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
-import { FunctionOptions } from './index';
+import { FunctionOptions, RegisterResult } from './index';
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';
@@ -25,133 +25,133 @@ import { TimerFunctionOptions } from './timer';
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function http(name: string, options: HttpFunctionOptions): void;
+export function http(name: string, options: HttpFunctionOptions): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'GET' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param handler The handler for this function
  */
-export function get(name: string, handler: HttpHandler): void;
+export function get(name: string, handler: HttpHandler): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'GET' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function get(name: string, options: HttpMethodFunctionOptions): void;
+export function get(name: string, options: HttpMethodFunctionOptions): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'PUT' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param handler The handler for this function
  */
-export function put(name: string, handler: HttpHandler): void;
+export function put(name: string, handler: HttpHandler): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'PUT' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function put(name: string, options: HttpMethodFunctionOptions): void;
+export function put(name: string, options: HttpMethodFunctionOptions): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'POST' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param handler The handler for this function
  */
-export function post(name: string, handler: HttpHandler): void;
+export function post(name: string, handler: HttpHandler): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'POST' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function post(name: string, options: HttpMethodFunctionOptions): void;
+export function post(name: string, options: HttpMethodFunctionOptions): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'PATCH' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param handler The handler for this function
  */
-export function patch(name: string, handler: HttpHandler): void;
+export function patch(name: string, handler: HttpHandler): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'PATCH' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function patch(name: string, options: HttpMethodFunctionOptions): void;
+export function patch(name: string, options: HttpMethodFunctionOptions): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'DELETE' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param handler The handler for this function
  */
-export function deleteRequest(name: string, handler: HttpHandler): void;
+export function deleteRequest(name: string, handler: HttpHandler): RegisterResult;
 
 /**
  * Registers an http function in your app that will be triggered by making a 'DELETE' request to the function url
  * @param name The name of the function. This will be the route unless a route is explicitly configured in the `HttpTriggerOptions`
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function deleteRequest(name: string, options: HttpMethodFunctionOptions): void;
+export function deleteRequest(name: string, options: HttpMethodFunctionOptions): RegisterResult;
 
 /**
  * Registers a timer function in your app that will be triggered on a schedule
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function timer(name: string, options: TimerFunctionOptions): void;
+export function timer(name: string, options: TimerFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever an item is added to a storage blob path
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function storageBlob(name: string, options: StorageBlobFunctionOptions): void;
+export function storageBlob(name: string, options: StorageBlobFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever an item is added to a storage queue
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function storageQueue(name: string, options: StorageQueueFunctionOptions): void;
+export function storageQueue(name: string, options: StorageQueueFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever a message is added to a service bus queue
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function serviceBusQueue(name: string, options: ServiceBusQueueFunctionOptions): void;
+export function serviceBusQueue(name: string, options: ServiceBusQueueFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever a message is added to a service bus topic
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function serviceBusTopic(name: string, options: ServiceBusTopicFunctionOptions): void;
+export function serviceBusTopic(name: string, options: ServiceBusTopicFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever a message is added to an event hub
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function eventHub(name: string, options: EventHubFunctionOptions): void;
+export function eventHub(name: string, options: EventHubFunctionOptions): RegisterResult;
 
 /**
  * Registers a function in your app that will be triggered whenever an event is sent by an event grid source
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function eventGrid(name: string, options: EventGridFunctionOptions): void;
+export function eventGrid(name: string, options: EventGridFunctionOptions): RegisterResult;
 
 /**
  * Registers a Cosmos DB function in your app that will be triggered whenever inserts and updates occur (not deletions)
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
+export function cosmosDB(name: string, options: CosmosDBFunctionOptions): RegisterResult;
 
 /**
  * Registers a generic function in your app that will be triggered based on the type specified in `options.trigger.type`
@@ -159,7 +159,7 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
-export function generic(name: string, options: FunctionOptions): void;
+export function generic(name: string, options: FunctionOptions): RegisterResult;
 
 export function onTerminate(handler: AppTerminateHandler): Disposable;
 export function onStart(handler: AppStartHandler): Disposable;

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -7,7 +7,7 @@ import { InvocationContext, LogHandler } from './InvocationContext';
 /**
  * Represents a type which can release resources, such as event listening or a timer.
  */
-export class Disposable {
+export declare class Disposable {
     /**
      * Combine many disposable-likes into one. You can use this method when having objects with a dispose function which aren't instances of `Disposable`.
      *

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -20,7 +20,28 @@ export interface PostInvocationOptions {
     filter?: HookFilter | HookFilter[];
 }
 
-export type HookFilter = string | ((context: InvocationContext) => boolean);
+export type HookFilter = string | HookFilterObject | ((context: InvocationContext) => boolean);
+
+/**
+ * An object that can be passed as a filter on invocation hooks
+ * to limit the execution of hooks to particular function invocations
+ */
+export interface HookFilterObject {
+    /**
+     * Execute hooks only on invocations of the functions with one of these names
+     */
+    functionNames?: string[];
+
+    /**
+     * Execute hooks only on invocations of functions with one of these trigger types
+     */
+    triggerTypes?: string[];
+
+    /**
+     * Execute hooks only on invocations with one of these invocation IDs
+     */
+    invocationIds?: string[];
+}
 
 export type AppStartHandler = (context: AppStartContext) => void | Promise<void>;
 export type AppTerminateHandler = (context: AppTerminateContext) => void | Promise<void>;

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -161,6 +161,12 @@ export declare class PreInvocationContext extends InvocationHookContext {
      * The function handler for this specific invocation. Changes to this value _will_ affect the function itself
      */
     functionHandler: FunctionHandler;
+
+    /**
+     * Aborts the current invocation of the function.
+     * Calling this method will cause your function execution to not run.
+     */
+    abort(): void;
 }
 
 export interface PreInvocationContextInit extends InvocationHookContextInit {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -5,8 +5,23 @@ import { FunctionHandler } from '.';
 import { InvocationContext, LogHandler } from './InvocationContext';
 
 export type HookHandler = (context: HookContext) => void | Promise<void>;
+
 export type PreInvocationHandler = (context: PreInvocationContext) => void | Promise<void>;
+
+export interface PreInvocationOptions {
+    handler: PreInvocationHandler;
+    filter?: HookFilter | HookFilter[];
+}
+
 export type PostInvocationHandler = (context: PostInvocationContext) => void | Promise<void>;
+
+export interface PostInvocationOptions {
+    handler: PostInvocationHandler;
+    filter?: HookFilter | HookFilter[];
+}
+
+export type HookFilter = string | ((context: InvocationContext) => boolean);
+
 export type AppStartHandler = (context: AppStartContext) => void | Promise<void>;
 export type AppTerminateHandler = (context: AppTerminateContext) => void | Promise<void>;
 

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -15,22 +15,38 @@ type HookData = { [key: string]: any };
 /**
  * Base class for all hook context objects
  */
-export declare abstract class HookContext {
+export declare class HookContext {
     /**
      * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
      */
     constructor(init?: HookContextInit);
 
     /**
-     * The recommended place to share data between hooks in the same scope (app-level vs invocation-level)
-     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     * Set a `propertyName` to some `value` to be shared with other hooks in the same scope (app-level vs invocation-level)
+     * @param propertyName The name of the property to set
+     * @param value The value to set
      */
-    readonly hookData: HookData;
+    set(propertyName: string, value: unknown): void;
+
     /**
-     * The recommended place to share data across scopes for all hooks
-     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     * Get the value of a `propertyName` shared with other hooks in the same scope (app-level vs invocation-level)
+     * @param propertyName the name of the property to get
      */
-    readonly appHookData: HookData;
+    get(propertyName: string): unknown;
+
+    /**
+     * Set a `propertyName` to some `value` to be shared across scopes for all hooks
+     *
+     * @param propertyName The name of the property to set
+     * @param value The value to set
+     */
+    setGlobal(propertyName: string, value: unknown): void;
+
+    /**
+     * Get the value of a `propertyName` shared across scopes for all hooks
+     * @param propertyName The name of the property to get
+     */
+    getGlobal(propertyName: string): unknown;
 }
 
 export interface HookContextInit {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -4,55 +4,36 @@
 import { FunctionHandler } from '.';
 import { InvocationContext, LogHandler } from './InvocationContext';
 
-export type HookHandler = (context: HookContext) => void | Promise<void>;
-
-export type PreInvocationHandler = (context: PreInvocationContext) => void | Promise<void>;
-
-export interface PreInvocationOptions {
-    handler: PreInvocationHandler;
-    filter?: HookFilter | HookFilter[];
-}
-
-export type PostInvocationHandler = (context: PostInvocationContext) => void | Promise<void>;
-
-export interface PostInvocationOptions {
-    handler: PostInvocationHandler;
+/**
+ * Represents a type which can release resources, such as event listening or a timer.
+ */
+export class Disposable {
     /**
-     * If multiple filters ares provided,
-     * the hook is run only if satisfies _all_ of the provided filters
+     * Combine many disposable-likes into one. You can use this method when having objects with a dispose function which aren't instances of `Disposable`.
+     *
+     * @param disposableLikes Objects that have at least a `dispose`-function member. Note that asynchronous dispose-functions aren't awaited.
+     * @return Returns a new disposable which, upon dispose, will dispose all provided disposables.
      */
-    filter?: HookFilter | HookFilter[];
-}
+    static from(...disposableLikes: { dispose: () => any }[]): Disposable;
 
-export type HookFilter = string | HookFilterObject | ((context: InvocationContext) => boolean);
+    /**
+     * Creates a new disposable that calls the provided function on dispose.
+     * *Note* that an asynchronous function is not awaited.
+     *
+     * @param callOnDispose Function that disposes something.
+     */
+    constructor(callOnDispose: () => any);
+
+    /**
+     * Dispose this object.
+     */
+    dispose(): any;
+}
 
 /**
- * An object that can be passed as a filter on invocation hooks
- * to limit the execution of hooks to particular function invocations
- *
- * The hook is run if it satisfies _any_ of the supplied criteria
+ * A generic handler for hooks
  */
-export interface HookFilterObject {
-    /**
-     * Execute hooks only on invocations of the functions with one of these names
-     */
-    functionNames?: string[];
-
-    /**
-     * Execute hooks only on invocations of functions with one of these trigger types
-     */
-    triggerTypes?: string[];
-
-    /**
-     * Execute hooks only on invocations with one of these invocation IDs
-     */
-    invocationIds?: string[];
-}
-
-export type AppStartHandler = (context: AppStartContext) => void | Promise<void>;
-export type AppTerminateHandler = (context: AppTerminateContext) => void | Promise<void>;
-
-type HookData = { [key: string]: any };
+export type HookHandler = (context: HookContext) => void | Promise<void>;
 
 /**
  * Base class for all hook context objects
@@ -91,20 +72,137 @@ export declare class HookContext {
     getGlobal(propertyName: string): unknown;
 }
 
+/**
+ * Object used to pass data between hooks
+ */
+export type HookData = { [key: string]: any };
+
+/**
+ * Base interface for objects passed to HookContext constructors.
+ * For testing purposes only.
+ */
 export interface HookContextInit {
     /**
+     * This object will be used to persist values between hooks
+     * of the same level (invocation-level vs app-level)
+     *
      * Defaults to empty object if not specified
      */
     hookData?: HookData;
 
     /**
+     * This object will be used to persist global values
+     *
      * Defaults to empty object if not specified
      */
     appHookData?: HookData;
 }
 
 /**
- * Base class for all invocation hook context objects
+ * Handler for app start hooks
+ */
+export type AppStartHandler = (context: AppStartContext) => void | Promise<void>;
+
+/**
+ * Context on a function app that is about to be started
+ * This object will be passed to all app start hooks
+ */
+export declare class AppStartContext extends HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: AppStartContextInit);
+
+    /**
+     * Absolute directory of the function app
+     */
+    functionAppDirectory: string;
+}
+
+/**
+ * Object passed to AppStartContext constructors.
+ * For testing purposes only
+ */
+export interface AppStartContextInit extends HookContextInit {
+    /**
+     * Defaults to 'unknown'
+     */
+    functionAppDirectory?: string;
+}
+
+/**
+ * Handler for app terminate hooks
+ */
+export type AppTerminateHandler = (context: AppTerminateContext) => void | Promise<void>;
+
+/**
+ * Context on a function app that is about to be terminated
+ * This object will be passed to all app terminate hooks
+ */
+export declare class AppTerminateContext extends HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: AppTerminateContextInit);
+}
+
+/**
+ * Object passed to AppTerminateContext constructors.
+ * For testing purposes only
+ */
+export interface AppTerminateContextInit extends HookContextInit {}
+
+/**
+ * Options for registering a pre-invocation hook
+ * This object can be passed to `onPreInvocation`
+ */
+export interface PreInvocationOptions {
+    /**
+     * The pre-invocation handler to register
+     */
+    handler: PreInvocationHandler;
+
+    /**
+     * Optional filter to determine which functions this handler should be invoked for.
+     * If multiple filters are provided,
+     * the hook is run only if satisfies _all_ of the provided filters
+     */
+    filter?: HookFilter | HookFilter[];
+}
+
+export type HookFilter =
+    | string // The hook is run if the function name matches this string
+    | HookFilterObject // The hook is run if the function invocation satisfies _any_ of the supplied criteria
+    | ((context: InvocationContext) => boolean); // The hook is run if this function returns true
+
+/**
+ * An object that can be passed as a filter on invocation hooks
+ * The hook is run if it satisfies _any_ of the supplied criteria in this object
+ */
+export interface HookFilterObject {
+    /**
+     * Execute hooks only on invocations of the functions with one of these names
+     */
+    functionNames?: string[];
+
+    /**
+     * Execute hooks only on invocations of functions with one of these trigger types
+     */
+    triggerTypes?: string[];
+
+    /**
+     * Execute hooks only on invocations with one of these invocation IDs
+     */
+    invocationIds?: string[];
+}
+
+/**
+ * Handler for pre-invocation hooks
+ */
+export type PreInvocationHandler = (context: PreInvocationContext) => void | Promise<void>;
+
+/**
+ * Base class for all invocation hook context objects (pre-invocation and post-invocation)
  */
 export declare abstract class InvocationHookContext extends HookContext {
     /**
@@ -156,6 +254,10 @@ export declare abstract class InvocationHookContext extends HookContext {
     error(...args: any[]): void;
 }
 
+/**
+ * Base interface passed to invocation hook context constructors.
+ * For testing purposes only
+ */
 interface InvocationHookContextInit extends HookContextInit {
     /**
      * Defaults to new InvocationContext with default values if not specified
@@ -163,14 +265,14 @@ interface InvocationHookContextInit extends HookContextInit {
     invocationContext?: InvocationContext;
 
     /**
-     * Defaults to logger on the invocation context if not specified
+     * Defaults to the logger on the invocation context if not specified
      */
     logHandler?: LogHandler;
 }
 
 /**
  * Context on a function that is about to be executed
- * This object will be passed to all pre invocation hooks
+ * This object will be passed to all pre-invocation hooks
  */
 export declare class PreInvocationContext extends InvocationHookContext {
     /**
@@ -191,11 +293,15 @@ export declare class PreInvocationContext extends InvocationHookContext {
 
     /**
      * Aborts the current invocation of the function.
-     * Calling this method will cause your function execution to not run.
+     * Calling this method _will_ cause your function execution to not run.
      */
     abort(): void;
 }
 
+/**
+ * Object passed to PreInvocationContext constructors.
+ * For testing purposes only
+ */
 export interface PreInvocationContextInit extends InvocationHookContextInit {
     /**
      * Defaults to empty array if not specified
@@ -208,17 +314,17 @@ export interface PreInvocationContextInit extends InvocationHookContextInit {
     functionHandler?: FunctionHandler;
 
     /**
-     * This is set automatically by the Azure Functions runtime. You should not set this yourself
+     * This is set by the Azure Functions runtime. You should not set this yourself
      */
     coreContext?: PreInvocationCoreContext;
 }
 
 /**
- * Context for Pre Invocation hooks coming from the Core API
+ * Context for pre-invocation hooks coming from the Core API
  * This object is relevant only for hooks that are registered using the Core API
  * You should not construct this object yourself
  */
-interface PreInvocationCoreContext {
+export interface PreInvocationCoreContext {
     /**
      * The input values for this specific invocation.
      * Changes to this array _will_ affect the inputs passed to your function
@@ -231,6 +337,29 @@ interface PreInvocationCoreContext {
      */
     functionCallback: FunctionHandler;
 }
+
+/**
+ * Options for registering a post-invocation hook
+ * This object can be passed to `onPostInvocation`
+ */
+export interface PostInvocationOptions {
+    /**
+     * The pre-invocation handler to register
+     */
+    handler: PostInvocationHandler;
+
+    /**
+     * Optional filter to determine which functions this handler should be invoked for.
+     * If multiple filters are provided,
+     * the hook is run only if satisfies _all_ of the provided filters
+     */
+    filter?: HookFilter | HookFilter[];
+}
+
+/**
+ * Handler for post-invocation hooks
+ */
+export type PostInvocationHandler = (context: PostInvocationContext) => void | Promise<void>;
 
 /**
  * Context on a function that has just executed
@@ -258,6 +387,10 @@ export declare class PostInvocationContext extends InvocationHookContext {
     errorResult: any;
 }
 
+/**
+ * Object passed to PostInvocationContext constructors.
+ * For testing purposes only
+ */
 export interface PostInvocationContextInit extends InvocationHookContextInit {
     /**
      * Defaults to empty array if not specified
@@ -302,62 +435,4 @@ interface PostInvocationCoreContext {
      * Changes to this value _will_ affect the overall result of the function
      */
     error: any;
-}
-
-/**
- * Context on a function app that is about to be started
- * This object will be passed to all app start hooks
- */
-export declare class AppStartContext extends HookContext {
-    /**
-     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
-     */
-    constructor(init?: AppStartContextInit);
-
-    /**
-     * Absolute directory of the function app
-     */
-    functionAppDirectory: string;
-}
-
-export interface AppStartContextInit extends HookContextInit {
-    /**
-     * Defaults to 'unknown'
-     */
-    functionAppDirectory?: string;
-}
-
-export declare class AppTerminateContext extends HookContext {
-    /**
-     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
-     */
-    constructor(init?: AppTerminateContextInit);
-}
-
-export interface AppTerminateContextInit extends HookContextInit {}
-
-/**
- * Represents a type which can release resources, such as event listening or a timer.
- */
-export class Disposable {
-    /**
-     * Combine many disposable-likes into one. You can use this method when having objects with a dispose function which aren't instances of `Disposable`.
-     *
-     * @param disposableLikes Objects that have at least a `dispose`-function member. Note that asynchronous dispose-functions aren't awaited.
-     * @return Returns a new disposable which, upon dispose, will dispose all provided disposables.
-     */
-    static from(...disposableLikes: { dispose: () => any }[]): Disposable;
-
-    /**
-     * Creates a new disposable that calls the provided function on dispose.
-     * *Note* that an asynchronous function is not awaited.
-     *
-     * @param callOnDispose Function that disposes something.
-     */
-    constructor(callOnDispose: () => any);
-
-    /**
-     * Dispose this object.
-     */
-    dispose(): any;
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -160,9 +160,9 @@ export declare class PostInvocationContext extends InvocationHookContext {
     result: any;
 
     /**
-     * The error for the function, or null if there is no error. Changes to this value _will_ affect the overall result of the function
+     * The error thrown by the function, or null if there is no error. Changes to this value _will_ affect the overall result of the function
      */
-    error: any;
+    errorResult: any;
 }
 
 export interface PostInvocationContextInit extends InvocationHookContextInit {
@@ -174,7 +174,7 @@ export interface PostInvocationContextInit extends InvocationHookContextInit {
     /**
      * Defaults to `null` if not specified
      */
-    error?: any;
+    errorResult?: any;
 }
 
 /**

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -17,6 +17,10 @@ export type PostInvocationHandler = (context: PostInvocationContext) => void | P
 
 export interface PostInvocationOptions {
     handler: PostInvocationHandler;
+    /**
+     * If multiple filters ares provided,
+     * the hook is run only if satisfies _all_ of the provided filters
+     */
     filter?: HookFilter | HookFilter[];
 }
 
@@ -25,6 +29,8 @@ export type HookFilter = string | HookFilterObject | ((context: InvocationContex
 /**
  * An object that can be passed as a filter on invocation hooks
  * to limit the execution of hooks to particular function invocations
+ *
+ * The hook is run if it satisfies _any_ of the supplied criteria
  */
 export interface HookFilterObject {
     /**

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionHandler } from '.';
+import { InvocationContext } from './InvocationContext';
+
+export type HookCallback = (context: HookContext) => void | Promise<void>;
+export type PreInvocationCallback = (context: PreInvocationContext) => void | Promise<void>;
+export type PostInvocationCallback = (context: PostInvocationContext) => void | Promise<void>;
+export type AppStartCallback = (context: AppStartContext) => void | Promise<void>;
+export type AppTerminateCallback = (context: AppTerminateContext) => void | Promise<void>;
+
+type HookData = { [key: string]: any };
+
+/**
+ * Base interface for all hook context objects
+ */
+export interface HookContext {
+    /**
+     * The recommended place to share data between hooks in the same scope (app-level vs invocation-level)
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly hookData: HookData;
+    /**
+     * The recommended place to share data across scopes for all hooks
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly appHookData: HookData;
+}
+
+/**
+ * Context on a function that is about to be executed
+ * This object will be passed to all pre invocation hooks
+ */
+export interface PreInvocationContext extends HookContext {
+    /**
+     * The context object passed to the function
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly invocationContext: InvocationContext;
+
+    /**
+     * The arguments passed to this specific invocation. Changes to this array _will_ affect the inputs passed to your function
+     */
+    args: any[];
+
+    /**
+     * The function callback for this specific invocation. Changes to this value _will_ affect the function itself
+     */
+    functionCallback: FunctionHandler;
+}
+
+/**
+ * Context on a function that has just executed
+ * This object will be passed to all post invocation hooks
+ */
+export interface PostInvocationContext extends HookContext {
+    /**
+     * The context object passed to the function
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly invocationContext: InvocationContext;
+
+    /**
+     * The arguments passed to this specific invocation
+     */
+    args: any[];
+
+    /**
+     * The result of the function, or null if there is no result. Changes to this value _will_ affect the overall result of the function
+     */
+    result: any;
+
+    /**
+     * The error for the function, or null if there is no error. Changes to this value _will_ affect the overall result of the function
+     */
+    error: any;
+}
+
+/**
+ * Context on a function app that is about to be started
+ * This object will be passed to all app start hooks
+ */
+export interface AppStartContext extends HookContext {
+    /**
+     * Absolute directory of the function app
+     */
+    functionAppDirectory: string;
+}
+
+export type AppTerminateContext = HookContext;
+
+/**
+ * Represents a type which can release resources, such as event listening or a timer.
+ */
+export class Disposable {
+    /**
+     * Combine many disposable-likes into one. You can use this method when having objects with a dispose function which aren't instances of `Disposable`.
+     *
+     * @param disposableLikes Objects that have at least a `dispose`-function member. Note that asynchronous dispose-functions aren't awaited.
+     * @return Returns a new disposable which, upon dispose, will dispose all provided disposables.
+     */
+    static from(...disposableLikes: { dispose: () => any }[]): Disposable;
+
+    /**
+     * Creates a new disposable that calls the provided function on dispose.
+     * *Note* that an asynchronous function is not awaited.
+     *
+     * @param callOnDispose Function that disposes something.
+     */
+    constructor(callOnDispose: () => any);
+
+    /**
+     * Dispose this object.
+     */
+    dispose(): any;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,7 @@ export * from './cosmosDB.v4';
 export * from './eventGrid';
 export * from './eventHub';
 export * from './generic';
+export * from './hooks';
 export * from './http';
 export * as input from './input';
 export * as output from './output';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -121,13 +121,13 @@ export interface FunctionOutput extends Record<string, unknown> {
 export interface RegisterResult {
     /**
      * Register a hook to be run before executions of this function
-     * @param handler the hook handler
+     * @param handler the pre-invocation hook handler
      */
     onPreInvocation: (handler: PreInvocationHandler) => RegisterResult;
 
     /**
      * Register a hook to be run after executions of this function
-     * @param handler the hook handler
+     * @param handler the post-invocation hook handler
      */
     onPostInvocation: (handler: PostInvocationHandler) => RegisterResult;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { InvocationContext } from './InvocationContext';
+import { PostInvocationHandler, PreInvocationHandler } from './hooks';
 
 export * from './InvocationContext';
 export * as app from './app';
@@ -112,4 +113,21 @@ export interface FunctionOutput extends Record<string, unknown> {
      * If using the `output` namespace to create this object, the name will be auto-generated for you
      */
     name: string;
+}
+
+/**
+ * Result of registering a function
+ */
+export interface RegisterResult {
+    /**
+     * Register a hook to be run before executions of this function
+     * @param handler the hook handler
+     */
+    onPreInvocation: (handler: PreInvocationHandler) => RegisterResult;
+
+    /**
+     * Register a hook to be run after executions of this function
+     * @param handler the hook handler
+     */
+    onPostInvocation: (handler: PostInvocationHandler) => RegisterResult;
 }


### PR DESCRIPTION
This PR builds on top of the worker-provided core hooks and adds official hooks support in v4.x of the library package. For this work, I erred on the side of providing as many options and customer requests as possible, expecting that with discussion, we probably won't end up merging everything, and we can decide what we want to keep and what we won't support.

## Hooks supported

1. App Start hooks
2. App terminate hooks
3. Pre-Invocation hooks
4. PostInvocation hooks
5. Generic hooks

## Ways of registering a hook

There are multiple ways you can register a hook

### Using the dedicated API with the handler directly (all hooks)

```TS
const onStartHandler: AppStartHandler = async (_context: AppStartContext) => {
    console.log('this hook will be run at the start of the app.');
}
app.onStart(onStartHandler);

const onTerminateHandler: AppTerminateHandler = async (_context: AppTerminateContext) => {
    console.log('This hook will be run before grateful shutdown of the app.');
};
app.onTerminate(onTerminateHandler);

const preInvocHandler: PreInvocationHandler = async (context: PreInvocationContext) => {
    context.log("This hook will be run before every invocation.");
}
app.onPreInvocation(preInvocHandler);

const postInvocHandler: PostInvocationHandler = async (context: PostInvocationContext) => {
    context.log("This hook will be run after every invocation.");
}
app.onPostInvocation(postInvocHandler);
```

### Using generic API (all hooks)

```TS
app.on('appStart', onStartHandler);

app.on('appTerminate', onTerminateHandler);

app.on('preInvocation', preInvocHandler);

app.on('postInvocation', postInvocHandler);
```


### Using an options object (invocation hooks only)

```TS
app.onPreInvocation({
    handler: preInvocHandler
});

app.onPostInvocation({ 
    filter: {
        functionNames: ['httpTrigger1'], // more on filters later
    },
    handler: postInvocHandler 
});
```

### Trailing from registering a function (invocation hooks only)

```TS
app.http('httpTrigger1', {
    methods: ['GET', 'POST'],
    authLevel: 'anonymous',
    handler: httpTrigger1
}).onPreInvocation(async (context) => {
    context.log(`This hook will only be run before this function`);
}).onPostInvocation(async (context) => {
    context.log(`This hook will only be run after this function.`);
});
```

## Filtering hook executions (invocation hooks only)

When registering an invocation hook (pre-invocation or post-invocation), you can specify a filter property to narrow down which function invocations the hook is run for.

There are three types of filters that can be provided:

### string filter (function name)

```TS
app.onPreInvocation({
    filter: 'httpTrigger1', // this hook will only be run for functions with this name
    handler: preInvocHandler
});
```

### function filter

```TS
app.onPreInvocation({
    // this hook will only be run if this function returns true
    filter: (context: InvocationContext) => context.extraInputs.get('name') === 'customCheck',
    handler: preInvocHandler
});
```

### object filter

```TS
app.onPreInvocation({
    // this hook will only be run if 
    filter: {
        // the function matches one of those name, OR
        functionNames: ['httpTrigger1', 'httpTrigger2'],
        // it has one of these trigger types, OR
        triggerTypes: ['orchestrationTrigger'],
        // it has one of these invocation ids
        invocationIds: ['1234', '5678'],
    },
    handler: preInvocHandler
});
```

### AND'ing filters

Multiple filters can also be provided, and if an array is provided, the hook will only be run if the function invocation satisfied ALL of the provided filters:

```TS
app.onPreInvocation({
    // this hook will only be run if 
    filter: [
        // it has this function name, AND
        'httpTrigger1',
        {
            // it has this invocation id
            invocationIds: ['1234']
        }
    ],
    handler: preInvocHandler
});
```

## Sharing data between hooks

The `hookData` and `appHookData` from the core API are replaced with `context.get`, `context.set` (replacing `hookData`), `context.getGlobal` and `context.setGlobal` (replacing `appHookData`):

```TS
const onStartFunc: AppStartHandler = async (context: AppStartContext) => {
    // this will be available to all hooks
    context.setGlobal('globalKey', 'globalValue');
    context.set('localKey', 'localValue');
}
app.onStart(onStartFunc);

const preInvocHook: PreInvocationHandler = async (context: PreInvocationContext) => {
    assert(context.getGlobal('globalKey') === 'globalValue');
    assert(typeof context.get('appOnlyKey') === 'undefined');

    context.set('invocationOnlyKey', 'invocationOnlyValue');

}
app.onPreInvocation(preInvocHook);

const postInvocHook: PostInvocationHandler = async (context: PostInvocationContext) => {
    assert(context.getGlobal('globalKey') === 'globalValue');
    assert(typeof context.get('appOnlyKey') === 'undefined');
    assert(context.get('invocationOnlyKey') === 'invocationOnlyValue');
}
app.onPostInvocation(postInvocHook);

const onTerminateHook: AppTerminateHandler = async (context: AppTerminateContext) => {
    assert(context.get('appOnlyKey') === 'appOnlyValue');
    assert(context.getGlobal('globalKey') === 'globalValue');
    assert(typeof context.get('invocationOnlyKey') === 'undefined');
};
app.onTerminate(onTerminateHook);
```

## Aborting executions

Pre-invocation hooks can abort executions, which under the hood just replaces the function callback with one that just logs that the execution was aborted:

```TS
const preInvocHook: PreInvocationHandler = async (context: PreInvocationContext) => {
    context.abort()
}
app.onPreInvocation(preInvocHook);
```