### PR TITLE
Support service bus batching

### DIFF
--- a/types/InvocationContext.d.ts
+++ b/types/InvocationContext.d.ts
@@ -163,16 +163,16 @@ export interface InvocationContextExtraOutputs {
     /**
      * Set a secondary Service Bus queue output for this invocation
      * @output the configuration object for this Service Bus output
-     * @message the output message value
+     * @message the output message(s) value
      */
-    set(output: ServiceBusQueueOutput, message: unknown): void;
+    set(output: ServiceBusQueueOutput, messages: unknown): void;
 
     /**
      * Set a secondary Service Bus topic output for this invocation
      * @output the configuration object for this Service Bus output
-     * @message the output message value
+     * @message the output message(s) value
      */
-    set(output: ServiceBusTopicOutput, message: unknown): void;
+    set(output: ServiceBusTopicOutput, messages: unknown): void;
 
     /**
      * Set a secondary Event Hub output for this invocation

--- a/types/serviceBus.d.ts
+++ b/types/serviceBus.d.ts
@@ -4,7 +4,7 @@
 import { FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
-export type ServiceBusQueueHandler = (message: unknown, context: InvocationContext) => FunctionResult;
+export type ServiceBusQueueHandler = (messages: unknown, context: InvocationContext) => FunctionResult;
 
 export interface ServiceBusQueueFunctionOptions extends ServiceBusQueueTriggerOptions, Partial<FunctionOptions> {
     handler: ServiceBusQueueHandler;
@@ -27,6 +27,11 @@ export interface ServiceBusQueueTriggerOptions {
      * `true` if connecting to a [session-aware](https://docs.microsoft.com/azure/service-bus-messaging/message-sessions) queue. Default is `false`
      */
     isSessionsEnabled?: boolean;
+
+    /**
+     * Set to `many` in order to enable batching. If omitted or set to `one`, a single message is passed to the function.
+     */
+    cardinality?: 'many' | 'one';
 }
 export type ServiceBusQueueTrigger = FunctionTrigger & ServiceBusQueueTriggerOptions;
 
@@ -71,6 +76,11 @@ export interface ServiceBusTopicTriggerOptions {
      * `true` if connecting to a [session-aware](https://docs.microsoft.com/azure/service-bus-messaging/message-sessions) subscription. Default is `false`
      */
     isSessionsEnabled?: boolean;
+
+    /**
+     * Set to `many` in order to enable batching. If omitted or set to `one`, a single message is passed to the function.
+     */
+    cardinality?: 'many' | 'one';
 }
 export type ServiceBusTopicTrigger = FunctionTrigger & ServiceBusTopicTriggerOptions;
 


### PR DESCRIPTION
It's not documented [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=python-v2%2Cin-process%2Cextensionv5&pivots=programming-language-javascript) (which I will fix), but all you have to do is use the 'cardinality' setting just like event hubs. It was actually fixed years ago: https://github.com/Azure/azure-functions-servicebus-extension/issues/15

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/129