### PR TITLE
Add storage blob event grid source to types

### DIFF
--- a/types/storage.d.ts
+++ b/types/storage.d.ts
@@ -43,7 +43,14 @@ export interface StorageQueueOptions {
     connection: string;
 }
 
-export type StorageBlobTriggerOptions = StorageBlobOptions;
+export interface StorageBlobTriggerOptions extends StorageBlobOptions {
+    /**
+     * The source of the triggering event.
+     * Use `EventGrid` for an Event Grid-based blob trigger, which provides much lower latency.
+     * The default is `LogsAndContainerScan`, which uses the standard polling mechanism to detect changes in the container.
+     */
+    source?: 'EventGrid' | 'LogsAndContainerScan';
+}
 export type StorageBlobTrigger = FunctionTrigger & StorageBlobTriggerOptions;
 
 export type StorageBlobInputOptions = StorageBlobOptions;


### PR DESCRIPTION
This has been supported for a while, but not documented. Glenn just added the docs to other languages here: https://github.com/MicrosoftDocs/azure-docs-pr/pull/250781/files

Here's my PR to get it documented for Node.js: https://github.com/MicrosoftDocs/azure-docs-pr/pull/251167

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/131