### PR TITLE
Validate tag/version in release pipeline

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -19,17 +19,21 @@ resources:
     branch: v4.x
 
 jobs:
-- job: ReleaseTypes
+- job: Release
   pool:
     name: '1ES-Hosted-AzFunc'
     demands:
     - ImageOverride -equals MMSUbuntu20.04TLS
   steps:
+  - download: nodeLibraryCI
   - task: NodeTool@0
     displayName: 'Install Node.js'
     inputs:
       versionSpec: 18.x
-  - download: nodeLibraryCI
+  - script: npm ci
+    displayName: 'npm ci'
+  - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "$(Pipeline.Workspace)/nodeLibraryCI/drop"'
+    displayName: 'validate release'
   - script: mv *.tgz package.tgz
     displayName: 'Rename tgz file' # because the publish command below requires an exact path
     workingDirectory: '$(Pipeline.Workspace)/nodeLibraryCI/drop'

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "test": "ts-node ./test/index.ts",
         "lint": "eslint . --fix",
         "updateVersion": "ts-node ./scripts/updateVersion.ts",
+        "validateRelease": "ts-node ./scripts/validateRelease.ts",
         "watch": "webpack --watch --mode development"
     },
     "dependencies": {

--- a/scripts/validateRelease.ts
+++ b/scripts/validateRelease.ts
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { readdirSync } from 'fs-extra';
+import * as parseArgs from 'minimist';
+
+const args = parseArgs(process.argv.slice(2));
+if (args.publishTag && args.dropPath) {
+    validateRelease(args.publishTag, args.dropPath);
+} else {
+    console.log(`This script can be used to validate that a release tag and version are in an expected format
+
+Example usage:
+
+npm run validateRelease -- --publishTag preview --dropPath /example/path/`);
+    throw new Error('Invalid arguments');
+}
+
+function validateRelease(publishTag: string, dropPath: string): void {
+    const files = readdirSync(dropPath);
+    if (files.length !== 1) {
+        throw new Error('Drop path should have one tgz file');
+    }
+
+    const match = files[0].match(/^azure-functions-(.*)\.tgz$/);
+    if (!match) {
+        throw new Error(`Unrecognized tgz file name "${files[0]}"`);
+    }
+
+    const versionNumber = match[1];
+    let regex: RegExp;
+    let expectedFormat: string;
+    switch (publishTag) {
+        case 'preview':
+            regex = /^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/;
+            expectedFormat = 'x.x.x-alpha.x';
+            break;
+        case 'latest':
+            regex = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+            expectedFormat = 'x.x.x';
+            break;
+        default:
+            throw new Error(`Unrecognized publish tag "${publishTag}"`);
+    }
+    if (!regex.test(versionNumber)) {
+        throw new Error(
+            `Version number for tag "${publishTag}" should be in format "${expectedFormat}". Instead got "${versionNumber}"`
+        );
+    }
+}


### PR DESCRIPTION
The other day I accidentally published "v4.0.0-alpha.12.20230912.4" when I meant to publish "v4.0.0-alpha.12" because I forgot a step in the release process (Queueing a build without the build number in the version). This was not a big deal and easy-to-fix especially because this was for the preview tag, but I wanted to add some extra validation to prevent this kind of thing from happening in the future.

https://www.npmjs.com/package/@azure/functions?activeTab=versions

Here's an example (dry-run) release that would've prevented the problem:

https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=152906&view=logs&j=8d802004-fbbb-5f17-b73e-f23de0c1dec8&t=7a29959a-6c04-5e83-f8f0-319180787bbf