### PR TITLE
Add support for table input & output

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -8,6 +8,8 @@ import {
     GenericInputOptions,
     StorageBlobInput,
     StorageBlobInputOptions,
+    TableInput,
+    TableInputOptions,
 } from '@azure/functions';
 import { addBindingName } from './addBindingName';
 
@@ -15,6 +17,13 @@ export function storageBlob(options: StorageBlobInputOptions): StorageBlobInput 
     return addInputBindingName({
         ...options,
         type: 'blob',
+    });
+}
+
+export function table(options: TableInputOptions): TableInput {
+    return addInputBindingName({
+        ...options,
+        type: 'table',
     });
 }
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -20,6 +20,8 @@ import {
     StorageBlobOutputOptions,
     StorageQueueOutput,
     StorageQueueOutputOptions,
+    TableOutput,
+    TableOutputOptions,
 } from '@azure/functions';
 import { addBindingName } from './addBindingName';
 
@@ -34,6 +36,13 @@ export function storageBlob(options: StorageBlobOutputOptions): StorageBlobOutpu
     return addOutputBindingName({
         ...options,
         type: 'blob',
+    });
+}
+
+export function table(options: TableOutputOptions): TableOutput {
+    return addOutputBindingName({
+        ...options,
+        type: 'table',
     });
 }
 

--- a/types/InvocationContext.d.ts
+++ b/types/InvocationContext.d.ts
@@ -8,6 +8,7 @@ import { HttpOutput, HttpResponse } from './http';
 import { FunctionInput, FunctionOutput, FunctionTrigger } from './index';
 import { ServiceBusQueueOutput, ServiceBusTopicOutput } from './serviceBus';
 import { StorageBlobInput, StorageBlobOutput, StorageQueueOutput } from './storage';
+import { TableInput, TableOutput } from './table';
 
 /**
  * Contains metadata and helper methods specific to this invocation
@@ -109,6 +110,12 @@ export interface InvocationContextExtraInputs {
     get(input: StorageBlobInput): unknown;
 
     /**
+     * Get a secondary table input for this invocation
+     * @input the configuration object for this table input
+     */
+    get(input: TableInput): unknown;
+
+    /**
      * Get a secondary Cosmos DB documents input for this invocation
      * @input the configuration object for this Cosmos DB input
      */
@@ -145,6 +152,13 @@ export interface InvocationContextExtraOutputs {
      * @blob the blob output value
      */
     set(output: StorageBlobOutput, blob: unknown): void;
+
+    /**
+     * Set a secondary table output for this invocation
+     * @output the configuration object for this table output
+     * @tableEntity the table output value
+     */
+    set(output: TableOutput, tableEntity: unknown): void;
 
     /**
      * Set a secondary storage queue entry output for this invocation

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ export * as input from './input';
 export * as output from './output';
 export * from './serviceBus';
 export * from './storage';
+export * from './table';
 export * from './timer';
 export * as trigger from './trigger';
 

--- a/types/input.d.ts
+++ b/types/input.d.ts
@@ -5,11 +5,17 @@ import { CosmosDBInput, CosmosDBInputOptions } from './cosmosDB';
 import { GenericInputOptions } from './generic';
 import { FunctionInput } from './index';
 import { StorageBlobInput, StorageBlobInputOptions } from './storage';
+import { TableInput, TableInputOptions } from './table';
 
 /**
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-input?pivots=programming-language-javascript)
  */
 export function storageBlob(options: StorageBlobInputOptions): StorageBlobInput;
+
+/**
+ * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-table-input?pivots=programming-language-javascript)
+ */
+export function table(options: TableInputOptions): TableInput;
 
 /**
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2-input?pivots=programming-language-javascript)

--- a/types/output.d.ts
+++ b/types/output.d.ts
@@ -14,6 +14,7 @@ import {
     ServiceBusTopicOutputOptions,
 } from './serviceBus';
 import { StorageBlobOutput, StorageBlobOutputOptions, StorageQueueOutput, StorageQueueOutputOptions } from './storage';
+import { TableOutput, TableOutputOptions } from './table';
 
 /**
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-output?&pivots=programming-language-javascript)
@@ -24,6 +25,11 @@ export function http(options: HttpOutputOptions): HttpOutput;
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-output?pivots=programming-language-javascript)
  */
 export function storageBlob(options: StorageBlobOutputOptions): StorageBlobOutput;
+
+/**
+ * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-table-output?pivots=programming-language-javascript)
+ */
+export function table(options: TableOutputOptions): TableOutput;
 
 /**
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-output?pivots=programming-language-javascript)

--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionInput, FunctionOutput } from './index';
+
+export interface TableOutputOptions {
+    /**
+     * The table name
+     */
+    tableName: string;
+
+    /**
+     * An app setting (or environment variable) with the storage connection string to be used by this table output
+     */
+    connection: string;
+
+    /**
+     * The partition key of the table entity to write.
+     */
+    partitionKey?: string;
+
+    /**
+     * The row key of the table entity to write.
+     */
+    rowKey?: string;
+}
+export type TableOutput = FunctionOutput & TableOutputOptions;
+
+export interface TableInputOptions {
+    /**
+     * The table name
+     */
+    tableName: string;
+
+    /**
+     * An app setting (or environment variable) with the storage connection string to be used by this table input
+     */
+    connection: string;
+
+    /**
+     * The partition key of the table entity to read.
+     */
+    partitionKey?: string;
+
+    /**
+     * The row key of the table entity to read. Can't be used with `take` or `filter`.
+     */
+    rowKey?: string;
+
+    /**
+     * The maximum number of entities to return. Can't be used with `rowKey`
+     */
+    take?: number;
+
+    /**
+     * An OData filter expression for the entities to return from the table. Can't be used with `rowKey`.
+     */
+    filter?: string;
+}
+export type TableInput = FunctionInput & TableInputOptions;


### PR DESCRIPTION
No one asked for this one, but all the languages use it as an example in the http trigger docs [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=python-v2%2Cin-process%2Cnodejs-v4%2Cfunctionsv2&pivots=programming-language-javascript#using-route-parameters), so that's what inspired me to add it. Plus it was pretty low-hanging fruit.

Technically the table binding supports both "Azure Cosmos DB for Table" and "Azure Table Storage", so that's why it's by itself instead of being grouped with storage or cosmos.

Lastly, table doesn't support triggers at all. Just input and output.