### PR TITLE
Introduce "connection" property

### DIFF
--- a/types/eventGrid.d.ts
+++ b/types/eventGrid.d.ts
@@ -18,7 +18,7 @@ export interface EventGridFunctionOptions extends EventGridTriggerOptions, Parti
 export interface EventGridTriggerOptions {}
 export type EventGridTrigger = FunctionTrigger & EventGridTriggerOptions;
 
-export interface EventGridOutputOptions {
+export interface EventGridOutputKeyOptions {
     /**
      * An app setting (or environment variable) that contains the URI for the custom topic
      */
@@ -29,6 +29,14 @@ export interface EventGridOutputOptions {
      */
     topicKeySetting: string;
 }
+export interface EventGridOutputConnectionOptions {
+    /**
+     * The value of the common prefix for the app setting that contains the `topicEndpointUri`.
+     * When setting the `connection` property, the `topicEndpointUri` and `topicKeySetting` properties should NOT be set.
+     */
+    connection: string;
+}
+export type EventGridOutputOptions = EventGridOutputKeyOptions | EventGridOutputConnectionOptions;
 export type EventGridOutput = FunctionOutput & EventGridOutputOptions;
 
 /**


### PR DESCRIPTION
This PR is a fix for issue #177.

Currently, customers must use a topic key to authenticate to Event Grid when using an Event Grid output binding. These changes allow customers to also leverage the "connection" property to implement identity-based authentication.

For more details on these two different authentication methods, please refer to the following [documentation](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-output?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cextensionv3&pivots=programming-language-typescript#connections).