### PR TITLE
Add native support for warmup trigger

### DIFF
--- a/src/addBindingName.ts
+++ b/src/addBindingName.ts
@@ -1,17 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+export { InvocationContext } from './InvocationContext';
 export { HttpRequest } from './http/HttpRequest';
 export { HttpResponse } from './http/HttpResponse';
-export { InvocationContext } from './InvocationContext';
 
 const bindingCounts: Record<string, number> = {};
 /**
- * If the host spawns multiple workers, it expects the metadata (including binding name) to be the same accross workers
- * That means we need to generate binding names in a deterministic fashion, so we'll do that using a count
+ * If the host spawns multiple workers, it expects the metadata (including binding name) to be the same across workers.
+ * Therefore, we need to generate binding names in a deterministic fashion. We'll do so using a count.
  * There's a tiny risk users register bindings in a non-deterministic order (i.e. async race conditions), but it's okay considering the following:
  * 1. We will track the count individually for each binding type. This makes the names more readable and reduces the chances a race condition will matter
- * 2. Users can manually specify the name themselves (aka if they're doing weird async stuff) and we will respect that
+ * 2. Users can manually specify the name themselves (e.g. if they're doing weird async stuff) and we will respect that
  * More info here: https://github.com/Azure/azure-functions-nodejs-worker/issues/638
  */
 export function addBindingName<T extends { type: string; name?: string }>(

--- a/src/addBindingName.ts
+++ b/src/addBindingName.ts
@@ -8,10 +8,10 @@ export { HttpResponse } from './http/HttpResponse';
 const bindingCounts: Record<string, number> = {};
 /**
  * If the host spawns multiple workers, it expects the metadata (including binding name) to be the same across workers.
- * Therefore, we need to generate binding names in a deterministic fashion. We'll do so using a count.
+ * That means we need to generate binding names in a deterministic fashion, so we'll do that using a count
  * There's a tiny risk users register bindings in a non-deterministic order (i.e. async race conditions), but it's okay considering the following:
  * 1. We will track the count individually for each binding type. This makes the names more readable and reduces the chances a race condition will matter
- * 2. Users can manually specify the name themselves (e.g. if they're doing weird async stuff) and we will respect that
+ * 2. Users can manually specify the name themselves (aka if they're doing weird async stuff) and we will respect that
  * More info here: https://github.com/Azure/azure-functions-nodejs-worker/issues/638
  */
 export function addBindingName<T extends { type: string; name?: string }>(

--- a/src/app.ts
+++ b/src/app.ts
@@ -147,8 +147,7 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void {
 }
 
 export function warmup(name: string, options: WarmupFunctionOptions): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    generic(name, convertToGenericOptions(options, <any>trigger.warmup));
+    generic(name, convertToGenericOptions(options, trigger.warmup));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import {
     StorageBlobFunctionOptions,
     StorageQueueFunctionOptions,
     TimerFunctionOptions,
+    WarmupFunctionOptions,
 } from '@azure/functions';
 import * as coreTypes from '@azure/functions-core';
 import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
@@ -143,6 +144,10 @@ export function eventGrid(name: string, options: EventGridFunctionOptions): void
 export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     generic(name, convertToGenericOptions(options, <any>trigger.cosmosDB));
+}
+
+export function warmup(name: string, options: WarmupFunctionOptions): void {
+    generic(name, convertToGenericOptions(options, trigger.warmup));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -147,7 +147,8 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void {
 }
 
 export function warmup(name: string, options: WarmupFunctionOptions): void {
-    generic(name, convertToGenericOptions(options, trigger.warmup));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    generic(name, convertToGenericOptions(options, <any>trigger.warmup));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -22,6 +22,8 @@ import {
     StorageQueueTriggerOptions,
     TimerTrigger,
     TimerTriggerOptions,
+    WarmupTrigger,
+    WarmupTriggerOptions,
 } from '@azure/functions';
 import { addBindingName } from './addBindingName';
 
@@ -87,6 +89,13 @@ export function cosmosDB(options: CosmosDBTriggerOptions): CosmosDBTrigger {
     return addTriggerBindingName({
         ...options,
         type: 'cosmosDBTrigger',
+    });
+}
+
+export function warmup(options: WarmupTriggerOptions): WarmupTrigger {
+    return addTriggerBindingName({
+        ...options,
+        type: 'warmupTrigger',
     });
 }
 

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -9,6 +9,7 @@ import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './h
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';
+import { WarmupFunctionOptions } from './warmup';
 
 /**
  * Registers an http function in your app that will be triggered by making a request to the function url
@@ -142,6 +143,13 @@ export function eventGrid(name: string, options: EventGridFunctionOptions): void
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
+
+/**
+ * Registers a function in your app that will be triggered when an instance is added to scale a running function app
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function warmup(name: string, options: WarmupFunctionOptions): void;
 
 /**
  * Registers a generic function in your app that will be triggered based on the type specified in `options.trigger.type`

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -145,7 +145,12 @@ export function eventGrid(name: string, options: EventGridFunctionOptions): void
 export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
 
 /**
- * Registers a function in your app that will be triggered when an instance is added to scale a running function app
+ * Registers a function in your app that will be triggered when an instance is added to scale a running function app.
+ * The warmup trigger is only called during scale-out operations, not during restarts or other non-scale startups.
+ * Make sure your logic can load all required dependencies without relying on the warmup trigger.
+ * Lazy loading is a good pattern to achieve this goal.
+ * The warmup trigger isn't available to apps running on the Consumption plan.
+ * For more information, please see the [Azure Functions warmup trigger documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript).
  * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,6 +20,7 @@ export * from './storage';
 export * from './table';
 export * from './timer';
 export * as trigger from './trigger';
+export * from './warmup';
 
 /**
  * Void if no `return` output is registered

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -68,7 +68,7 @@ export function eventGrid(options: EventGridTriggerOptions): EventGridTrigger;
 export function cosmosDB(options: CosmosDBTriggerOptions): CosmosDBTrigger;
 
 /**
- * [Link to docs and examples](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript)
+ * [Link to docs and examples](https://learn.microsoft.com/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript)
  */
 export function warmup(options: WarmupTriggerOptions): WarmupTrigger;
 

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -20,6 +20,7 @@ import {
     StorageQueueTriggerOptions,
 } from './storage';
 import { TimerTrigger, TimerTriggerOptions } from './timer';
+import { WarmupTrigger, WarmupTriggerOptions } from './warmup';
 
 /**
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger?&pivots=programming-language-javascript)
@@ -65,6 +66,11 @@ export function eventGrid(options: EventGridTriggerOptions): EventGridTrigger;
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?pivots=programming-language-javascript)
  */
 export function cosmosDB(options: CosmosDBTriggerOptions): CosmosDBTrigger;
+
+/**
+ * [Link to docs and examples](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript)
+ */
+export function warmup(options: WarmupTriggerOptions): WarmupTrigger;
 
 /**
  * A generic option that can be used for any trigger type

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FunctionOptions, FunctionResult, FunctionTrigger, RetryOptions } from './index';
+import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
 export type WarmupHandler = (warmupContext: object, context: InvocationContext) => FunctionResult;
@@ -10,12 +10,6 @@ export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<Fun
     handler: WarmupHandler;
 
     trigger?: WarmupTrigger;
-
-    /**
-     * An optional retry policy to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.
-     * Learn more [here](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
-     */
-    retry?: RetryOptions;
 }
 
 export interface WarmupTriggerOptions {}

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -1,21 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FunctionOptions, FunctionResult, FunctionTrigger, RetryOptions } from './index';
+import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
 export type WarmupHandler = (warmupContext: object, context: InvocationContext) => FunctionResult;
 
 export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<FunctionOptions> {
     handler: WarmupHandler;
-
-    trigger?: WarmupTrigger;
-
-    /**
-     * An optional retry policy to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.
-     * Learn more [here](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
-     */
-    retry?: RetryOptions;
 }
 
 export interface WarmupTriggerOptions {}

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionOptions, FunctionResult, FunctionTrigger, RetryOptions } from './index';
+import { InvocationContext } from './InvocationContext';
+
+export type WarmupHandler = (warmupContext: object, context: InvocationContext) => FunctionResult;
+
+export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<FunctionOptions> {
+    handler: WarmupHandler;
+
+    trigger?: WarmupTrigger;
+
+    /**
+     * An optional retry policy to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.
+     * Learn more [here](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
+     */
+    retry?: RetryOptions;
+}
+
+export interface WarmupTriggerOptions {}
+
+export type WarmupTrigger = FunctionTrigger & WarmupTriggerOptions;

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -4,7 +4,8 @@
 import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
-export type WarmupHandler = (warmupContext: object, context: InvocationContext) => FunctionResult;
+export interface WarmupContextOptions {}
+export type WarmupHandler = (warmupContext: WarmupContextOptions, context: InvocationContext) => FunctionResult;
 
 export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<FunctionOptions> {
     handler: WarmupHandler;
@@ -13,5 +14,4 @@ export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<Fun
 }
 
 export interface WarmupTriggerOptions {}
-
 export type WarmupTrigger = FunctionTrigger & WarmupTriggerOptions;

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -8,6 +8,8 @@ export type WarmupHandler = (warmupContext: object, context: InvocationContext) 
 
 export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<FunctionOptions> {
     handler: WarmupHandler;
+
+    trigger?: WarmupTrigger;
 }
 
 export interface WarmupTriggerOptions {}

--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
+import { FunctionOptions, FunctionResult, FunctionTrigger, RetryOptions } from './index';
 import { InvocationContext } from './InvocationContext';
 
 export type WarmupHandler = (warmupContext: object, context: InvocationContext) => FunctionResult;
@@ -10,6 +10,12 @@ export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<Fun
     handler: WarmupHandler;
 
     trigger?: WarmupTrigger;
+
+    /**
+     * An optional retry policy to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.
+     * Learn more [here](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
+     */
+    retry?: RetryOptions;
 }
 
 export interface WarmupTriggerOptions {}


### PR DESCRIPTION
This PR is a fix for issues #174 and #176.

Currently, users wanting to set up a [warmup trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript) need to use [generics](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Clinux%2Cazure-cli&pivots=nodejs-model-v4#generic-inputs-and-outputs). For example, they could write:

```
const { app, output, trigger } = require('@azure/functions');

app.generic('warmup', {
    trigger: trigger.generic({
        type: "warmupTrigger",
        direction: "in",
        name: "warmupContext"
    })
    handler: async (warmupContext, context) => {
        context.log('Function App instance is warm.');
    }
});

```

This works, but with the changes in this PR, users can now call the warmup trigger directly on `app`:

```
import { app, InvocationContext } from "@azure/functions";

export async function warmupFunction(warmupContext: object, context: InvocationContext): Promise<void> {
    context.log('Function App instance is warm.');
}

app.warmup('warmup', {
    handler: warmupFunction,
});

```