### PR TITLE
Add basic hook support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,8 @@
         ],
         "no-return-await": "off",
         "@typescript-eslint/return-await": "error",
-        "eqeqeq": "error"
+        "eqeqeq": "error",
+        "@typescript-eslint/no-empty-function": "off"
     },
     "ignorePatterns": [
         "**/*.js",

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FunctionHandler } from '@azure/functions';
 import * as coreTypes from '@azure/functions-core';
 import {
     CoreInvocationContext,
@@ -79,10 +78,13 @@ export class InvocationModel implements coreTypes.InvocationModel {
         return { context, inputs };
     }
 
-    async invokeFunction(context: InvocationContext, inputs: unknown[], handler: FunctionHandler): Promise<unknown> {
+    async invokeFunction(
+        context: InvocationContext,
+        inputs: unknown[],
+        handler: coreTypes.FunctionCallback
+    ): Promise<unknown> {
         try {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return await Promise.resolve(handler(inputs[0], context));
+            return await Promise.resolve(handler(...inputs, context));
         } finally {
             this.#isDone = true;
         }

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,19 +28,9 @@ import { toRpcDuration } from './converters/toRpcDuration';
 import * as output from './output';
 import * as trigger from './trigger';
 import { isTrigger } from './utils/isTrigger';
+import { tryGetCoreApiLazy } from './utils/tryGetCoreApiLazy';
 
-let coreApi: typeof coreTypes | undefined | null;
-function tryGetCoreApiLazy(): typeof coreTypes | null {
-    if (coreApi === undefined) {
-        try {
-            // eslint-disable-next-line @typescript-eslint/no-var-requires
-            coreApi = <typeof coreTypes>require('@azure/functions-core');
-        } catch {
-            coreApi = null;
-        }
-    }
-    return coreApi;
-}
+export * as hook from './hooks/registerHook';
 
 class ProgrammingModel implements coreTypes.ProgrammingModel {
     name = '@azure/functions';

--- a/src/hooks/AppStartContext.ts
+++ b/src/hooks/AppStartContext.ts
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { HookContext } from './HookContext';
+
+export class AppStartContext extends HookContext implements types.AppStartContext {}

--- a/src/hooks/AppTerminateContext.ts
+++ b/src/hooks/AppTerminateContext.ts
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { HookContext } from './HookContext';
+
+export class AppTerminateContext extends HookContext implements types.AppTerminateContext {}

--- a/src/hooks/HookContext.ts
+++ b/src/hooks/HookContext.ts
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { ReadOnlyError } from '../errors';
+import { nonNullProp } from '../utils/nonNull';
+
+export class HookContext implements types.HookContext {
+    #init: types.HookContextInit;
+
+    constructor(init?: types.HookContextInit) {
+        this.#init = init ?? {};
+        this.#init.hookData ??= {};
+    }
+
+    get hookData(): Record<string, unknown> {
+        return nonNullProp(this.#init, 'hookData');
+    }
+
+    set hookData(_value: unknown) {
+        throw new ReadOnlyError('hookData');
+    }
+}

--- a/src/hooks/InvocationHookContext.ts
+++ b/src/hooks/InvocationHookContext.ts
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { InvocationContext } from '../InvocationContext';
+import { ReadOnlyError } from '../errors';
+import { nonNullProp } from '../utils/nonNull';
+import { HookContext } from './HookContext';
+
+export class InvocationHookContext extends HookContext implements types.InvocationHookContext {
+    #init: types.InvocationHookContextInit;
+
+    constructor(init?: types.InvocationHookContextInit) {
+        super(init);
+        this.#init = init ?? {};
+        this.#init.inputs ??= [];
+        this.#init.invocationContext ??= new InvocationContext();
+    }
+
+    get invocationContext(): types.InvocationContext {
+        return nonNullProp(this.#init, 'invocationContext');
+    }
+
+    set invocationContext(_value: types.InvocationContext) {
+        throw new ReadOnlyError('invocationContext');
+    }
+
+    get inputs(): unknown[] {
+        return nonNullProp(this.#init, 'inputs');
+    }
+
+    set inputs(value: unknown[]) {
+        this.#init.inputs = value;
+    }
+}

--- a/src/hooks/PostInvocationContext.ts
+++ b/src/hooks/PostInvocationContext.ts
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { InvocationHookContext } from './InvocationHookContext';
+
+export class PostInvocationContext extends InvocationHookContext implements types.PostInvocationContext {
+    #init: types.PostInvocationContextInit;
+
+    constructor(init?: types.PostInvocationContextInit) {
+        super(init);
+        this.#init = init ?? {};
+    }
+
+    get result(): unknown {
+        return this.#init.result;
+    }
+
+    set result(value: unknown) {
+        this.#init.result = value;
+    }
+
+    get error(): unknown {
+        return this.#init.error;
+    }
+
+    set error(value: unknown) {
+        this.#init.error = value;
+    }
+}

--- a/src/hooks/PreInvocationContext.ts
+++ b/src/hooks/PreInvocationContext.ts
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { nonNullProp } from '../utils/nonNull';
+import { InvocationHookContext } from './InvocationHookContext';
+
+export class PreInvocationContext extends InvocationHookContext implements types.PreInvocationContext {
+    #init: types.PreInvocationContextInit;
+
+    constructor(init?: types.PreInvocationContextInit) {
+        super(init);
+        this.#init = init ?? {};
+        this.#init.functionCallback ??= () => {};
+    }
+
+    get functionHandler(): types.FunctionHandler {
+        return nonNullProp(this.#init, 'functionCallback');
+    }
+
+    set functionHandler(value: types.FunctionHandler) {
+        this.#init.functionCallback = value;
+    }
+}

--- a/src/hooks/registerHook.ts
+++ b/src/hooks/registerHook.ts
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AppStartHandler, AppTerminateHandler, PostInvocationHandler, PreInvocationHandler } from '@azure/functions';
+import * as coreTypes from '@azure/functions-core';
+import { Disposable } from '../utils/Disposable';
+import { tryGetCoreApiLazy } from '../utils/tryGetCoreApiLazy';
+import { AppStartContext } from './AppStartContext';
+import { AppTerminateContext } from './AppTerminateContext';
+import { PostInvocationContext } from './PostInvocationContext';
+import { PreInvocationContext } from './PreInvocationContext';
+
+function registerHook(hookName: string, callback: coreTypes.HookCallback): coreTypes.Disposable {
+    const coreApi = tryGetCoreApiLazy();
+    if (!coreApi) {
+        console.warn(
+            `WARNING: Skipping call to register ${hookName} hook because the "@azure/functions" package is in test mode.`
+        );
+        return new Disposable(() => {
+            console.warn(
+                `WARNING: Skipping call to dispose ${hookName} hook because the "@azure/functions" package is in test mode.`
+            );
+        });
+    } else {
+        return coreApi.registerHook(hookName, callback);
+    }
+}
+
+export function appStart(handler: AppStartHandler): Disposable {
+    return registerHook('appStart', (coreContext) => {
+        return handler(new AppStartContext(coreContext));
+    });
+}
+
+export function appTerminate(handler: AppTerminateHandler): Disposable {
+    return registerHook('appTerminate', (coreContext) => {
+        return handler(new AppTerminateContext(coreContext));
+    });
+}
+
+export function preInvocation(handler: PreInvocationHandler): Disposable {
+    return registerHook('preInvocation', (coreContext) => {
+        return handler(new PreInvocationContext(coreContext));
+    });
+}
+
+export function postInvocation(handler: PostInvocationHandler): Disposable {
+    return registerHook('postInvocation', (coreContext) => {
+        return handler(new PostInvocationContext(coreContext));
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+export { InvocationContext } from './InvocationContext';
 export * as app from './app';
+export { AppStartContext } from './hooks/AppStartContext';
+export { AppTerminateContext } from './hooks/AppTerminateContext';
+export { HookContext } from './hooks/HookContext';
+export { InvocationHookContext } from './hooks/InvocationHookContext';
+export { PostInvocationContext } from './hooks/PostInvocationContext';
+export { PreInvocationContext } from './hooks/PreInvocationContext';
 export { HttpRequest } from './http/HttpRequest';
 export { HttpResponse } from './http/HttpResponse';
 export * as input from './input';
-export { InvocationContext } from './InvocationContext';
 export * as output from './output';
 export * as trigger from './trigger';
+export { Disposable } from './utils/Disposable';

--- a/src/utils/Disposable.ts
+++ b/src/utils/Disposable.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 /**
- * Based off of the Node worker
- * https://github.com/Azure/azure-functions-nodejs-worker/blob/bf28d9c5ad4ed22c5e42c082471d16108abee140/src/Disposable.ts
+ * Based off of VS Code
+ * https://github.com/microsoft/vscode/blob/7bed4ce3e9f5059b5fc638c348f064edabcce5d2/src/vs/workbench/api/common/extHostTypes.ts#L65
  */
 export class Disposable {
     static from(...inDisposables: { dispose(): any }[]): Disposable {
@@ -27,7 +27,7 @@ export class Disposable {
     }
 
     dispose(): any {
-        if (this.#callOnDispose instanceof Function) {
+        if (typeof this.#callOnDispose === 'function') {
             this.#callOnDispose();
             this.#callOnDispose = undefined;
         }

--- a/src/utils/Disposable.ts
+++ b/src/utils/Disposable.ts
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Based off of the Node worker
+ * https://github.com/Azure/azure-functions-nodejs-worker/blob/bf28d9c5ad4ed22c5e42c082471d16108abee140/src/Disposable.ts
+ */
+export class Disposable {
+    static from(...inDisposables: { dispose(): any }[]): Disposable {
+        let disposables: ReadonlyArray<{ dispose(): any }> | undefined = inDisposables;
+        return new Disposable(function () {
+            if (disposables) {
+                for (const disposable of disposables) {
+                    if (disposable && typeof disposable.dispose === 'function') {
+                        disposable.dispose();
+                    }
+                }
+                disposables = undefined;
+            }
+        });
+    }
+
+    #callOnDispose?: () => any;
+
+    constructor(callOnDispose: () => any) {
+        this.#callOnDispose = callOnDispose;
+    }
+
+    dispose(): any {
+        if (this.#callOnDispose instanceof Function) {
+            this.#callOnDispose();
+            this.#callOnDispose = undefined;
+        }
+    }
+}

--- a/src/utils/tryGetCoreApiLazy.ts
+++ b/src/utils/tryGetCoreApiLazy.ts
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as coreTypes from '@azure/functions-core';
+
+let coreApi: typeof coreTypes | undefined | null;
+export function tryGetCoreApiLazy(): typeof coreTypes | null {
+    if (coreApi === undefined) {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            coreApi = <typeof coreTypes>require('@azure/functions-core');
+        } catch {
+            coreApi = null;
+        }
+    }
+    return coreApi;
+}

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -23,13 +23,6 @@ describe('hooks', () => {
         registeredHook.dispose();
     });
 
-    function validateHookContext(context: HookContext) {
-        expect(context.hookData).to.deep.equal({});
-        expect(() => {
-            context.hookData = {};
-        }).to.throw();
-    }
-
     it('AppTerminateContext', () => {
         const context = new AppTerminateContext();
         validateHookContext(context);
@@ -39,18 +32,6 @@ describe('hooks', () => {
         const context = new AppStartContext();
         validateHookContext(context);
     });
-
-    function validateInvocationHookContext(context: InvocationHookContext): void {
-        validateHookContext(context);
-        expect(context.inputs).to.deep.equal([]);
-        expect(context.invocationContext).to.deep.equal(new InvocationContext());
-
-        expect(() => {
-            context.invocationContext = <any>{};
-        }).to.throw();
-        context.inputs = ['change'];
-        expect(context.inputs).to.deep.equal(['change']);
-    }
 
     it('PreInvocationContext', () => {
         const context = new PreInvocationContext();
@@ -76,4 +57,23 @@ describe('hooks', () => {
         expect(context.error).to.equal(newError);
         expect(context.result).to.equal('test2');
     });
+
+    function validateInvocationHookContext(context: InvocationHookContext): void {
+        validateHookContext(context);
+        expect(context.inputs).to.deep.equal([]);
+        expect(context.invocationContext).to.deep.equal(new InvocationContext());
+
+        expect(() => {
+            context.invocationContext = <any>{};
+        }).to.throw();
+        context.inputs = ['change'];
+        expect(context.inputs).to.deep.equal(['change']);
+    }
+
+    function validateHookContext(context: HookContext) {
+        expect(context.hookData).to.deep.equal({});
+        expect(() => {
+            context.hookData = {};
+        }).to.throw();
+    }
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import 'mocha';
+import {
+    AppStartContext,
+    AppTerminateContext,
+    HookContext,
+    InvocationContext,
+    InvocationHookContext,
+    PostInvocationContext,
+    PreInvocationContext,
+    app,
+} from '../src/index';
+
+describe('hooks', () => {
+    it("register doesn't throw error in unit test mode", () => {
+        app.hook.appStart(() => {});
+        app.hook.appTerminate(() => {});
+        app.hook.postInvocation(() => {});
+        const registeredHook = app.hook.preInvocation(() => {});
+        registeredHook.dispose();
+    });
+
+    function validateHookContext(context: HookContext) {
+        expect(context.hookData).to.deep.equal({});
+        expect(() => {
+            context.hookData = {};
+        }).to.throw();
+    }
+
+    it('AppTerminateContext', () => {
+        const context = new AppTerminateContext();
+        validateHookContext(context);
+    });
+
+    it('AppStartContext', () => {
+        const context = new AppStartContext();
+        validateHookContext(context);
+    });
+
+    function validateInvocationHookContext(context: InvocationHookContext): void {
+        validateHookContext(context);
+        expect(context.inputs).to.deep.equal([]);
+        expect(context.invocationContext).to.deep.equal(new InvocationContext());
+
+        expect(() => {
+            context.invocationContext = <any>{};
+        }).to.throw();
+        context.inputs = ['change'];
+        expect(context.inputs).to.deep.equal(['change']);
+    }
+
+    it('PreInvocationContext', () => {
+        const context = new PreInvocationContext();
+        validateInvocationHookContext(context);
+        expect(typeof context.functionHandler).to.equal('function');
+
+        const updatedFunc = () => {
+            console.log('changed');
+        };
+        context.functionHandler = updatedFunc;
+        expect(context.functionHandler).to.equal(updatedFunc);
+    });
+
+    it('PostInvocationContext', () => {
+        const context = new PostInvocationContext();
+        validateInvocationHookContext(context);
+        expect(context.error).to.equal(undefined);
+        expect(context.result).to.equal(undefined);
+
+        const newError = new Error('test1');
+        context.error = newError;
+        context.result = 'test2';
+        expect(context.error).to.equal(newError);
+        expect(context.result).to.equal('test2');
+    });
+});

--- a/types-core/index.d.ts
+++ b/types-core/index.d.ts
@@ -278,7 +278,7 @@ declare module '@azure/functions-core' {
         inputs: unknown[];
     }
 
-    type FunctionCallback = (context: unknown, ...inputs: unknown[]) => unknown;
+    type FunctionCallback = (...args: unknown[]) => unknown;
 
     // #region rpc types
     interface RpcFunctionMetadata {

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -150,3 +150,5 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function generic(name: string, options: GenericFunctionOptions): void;
+
+export * as hook from './hooks/registerHook';

--- a/types/hooks/HookContext.d.ts
+++ b/types/hooks/HookContext.d.ts
@@ -12,7 +12,7 @@ export declare class HookContext {
 
     /**
      * The recommended place to store and share data between hooks in the same scope (app-level vs invocation-level).
-     * You should use a relatively unique property name so that it doesn't conflict with other hooks' data.
+     * You should use a unique property name so that it doesn't conflict with other hooks' data.
      * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
      */
     readonly hookData: Record<string, unknown>;

--- a/types/hooks/HookContext.d.ts
+++ b/types/hooks/HookContext.d.ts
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Base class for all hook context objects
+ */
+export declare class HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: HookContextInit);
+
+    /**
+     * The recommended place to store and share data between hooks in the same scope (app-level vs invocation-level).
+     * You should use a relatively unique property name so that it doesn't conflict with other hooks' data.
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly hookData: Record<string, unknown>;
+}
+
+/**
+ * Base interface for objects passed to HookContext constructors.
+ * For testing purposes only.
+ */
+export interface HookContextInit {
+    hookData?: Record<string, unknown>;
+}

--- a/types/hooks/appHooks.d.ts
+++ b/types/hooks/appHooks.d.ts
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { HookContext, HookContextInit } from './HookContext';
+
+/**
+ * Handler for app start hooks
+ */
+export type AppStartHandler = (context: AppStartContext) => void | Promise<void>;
+
+/**
+ * Context on a function app during app startup.
+ */
+export declare class AppStartContext extends HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: AppStartContextInit);
+}
+
+/**
+ * Handler for app terminate hooks
+ */
+export type AppTerminateHandler = (context: AppTerminateContext) => void | Promise<void>;
+
+/**
+ * Context on a function app during app termination.
+ */
+export declare class AppTerminateContext extends HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: AppTerminateContextInit);
+}
+
+/**
+ * Object passed to AppStartContext constructors.
+ * For testing purposes only
+ */
+export interface AppStartContextInit extends HookContextInit {}
+
+/**
+ * Object passed to AppTerminateContext constructors.
+ * For testing purposes only
+ */
+export interface AppTerminateContextInit extends HookContextInit {}

--- a/types/hooks/invocationHooks.d.ts
+++ b/types/hooks/invocationHooks.d.ts
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionHandler } from '../index';
+import { InvocationContext } from '../InvocationContext';
+import { HookContext, HookContextInit } from './HookContext';
+
+/**
+ * Handler for pre-invocation hooks.
+ */
+export type PreInvocationHandler = (context: PreInvocationContext) => void | Promise<void>;
+
+/**
+ * Context on a function before it executes.
+ */
+export declare class PreInvocationContext extends InvocationHookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: PreInvocationContextInit);
+
+    /**
+     * The arguments passed to this specific invocation.
+     * Changes to this array _will_ affect the inputs passed to your function
+     */
+    inputs: unknown[];
+
+    /**
+     * The function handler for this specific invocation. Changes to this value _will_ affect the function itself
+     */
+    functionHandler: FunctionHandler;
+}
+
+/**
+ * Handler for post-invocation hooks
+ */
+export type PostInvocationHandler = (context: PostInvocationContext) => void | Promise<void>;
+
+/**
+ * Context on a function after it executes.
+ */
+export declare class PostInvocationContext extends InvocationHookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: PostInvocationContextInit);
+
+    /**
+     * The arguments passed to this specific invocation.
+     */
+    inputs: unknown[];
+
+    /**
+     * The result of the function. Changes to this value _will_ affect the overall result of the function
+     */
+    result: unknown;
+
+    /**
+     * The error thrown by the function, or null/undefined if there is no error. Changes to this value _will_ affect the overall result of the function
+     */
+    error: unknown;
+}
+
+/**
+ * Base class for all invocation hook context objects
+ */
+export declare class InvocationHookContext extends HookContext {
+    /**
+     * For testing purposes only. This will always be constructed for you when run in the context of the Azure Functions runtime
+     */
+    constructor(init?: InvocationHookContextInit);
+
+    /**
+     * The context object passed to the function.
+     * This object is readonly. You may modify it, but attempting to overwrite it will throw an error
+     */
+    readonly invocationContext: InvocationContext;
+}
+
+/**
+ * Object passed to InvocationHookContext constructors.
+ * For testing purposes only
+ */
+export interface InvocationHookContextInit extends HookContextInit {
+    inputs?: unknown[];
+
+    invocationContext?: InvocationContext;
+}
+
+/**
+ * Object passed to PreInvocationContext constructors.
+ * For testing purposes only
+ */
+export interface PreInvocationContextInit extends InvocationHookContextInit {
+    functionCallback?: FunctionHandler;
+}
+
+/**
+ * Object passed to PostInvocationContext constructors.
+ * For testing purposes only
+ */
+export interface PostInvocationContextInit extends InvocationHookContextInit {
+    result?: unknown;
+
+    error?: unknown;
+}

--- a/types/hooks/registerHook.d.ts
+++ b/types/hooks/registerHook.d.ts
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Disposable } from '../index';
+import { AppStartHandler, AppTerminateHandler } from './appHooks';
+import { PostInvocationHandler, PreInvocationHandler } from './invocationHooks';
+
+/**
+ * Register a hook to be run at the start of your application
+ *
+ * @param handler the handler for the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function appStart(handler: AppStartHandler): Disposable;
+
+/**
+ * Register a hook to be run during graceful shutdown of your application.
+ * This hook will not be executed if your application is terminated forcefully.
+ * Hooks have a limited time to execute during the termination grace period.
+ *
+ * @param handler the handler for the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function appTerminate(handler: AppTerminateHandler): Disposable;
+
+/**
+ * Register a hook to be run before a function is invoked.
+ *
+ * @param handler the handler for the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function preInvocation(handler: PreInvocationHandler): Disposable;
+
+/**
+ * Register a hook to be run after a function is invoked.
+ *
+ * @param handler the handler for the hook
+ * @returns a `Disposable` object that can be used to unregister the hook
+ */
+export function postInvocation(handler: PostInvocationHandler): Disposable;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,9 @@ export * from './cosmosDB.v4';
 export * from './eventGrid';
 export * from './eventHub';
 export * from './generic';
+export * from './hooks/HookContext';
+export * from './hooks/appHooks';
+export * from './hooks/invocationHooks';
 export * from './http';
 export * as input from './input';
 export * as output from './output';
@@ -166,4 +169,30 @@ export interface Duration {
     minutes?: number;
     seconds?: number;
     milliseconds?: number;
+}
+
+/**
+ * Represents a type which can release resources, such as event listening or a timer.
+ */
+export declare class Disposable {
+    /**
+     * Combine many disposable-likes into one. You can use this method when having objects with a dispose function which aren't instances of `Disposable`.
+     *
+     * @param disposableLikes Objects that have at least a `dispose`-function member. Note that asynchronous dispose-functions aren't awaited.
+     * @return Returns a new disposable which, upon dispose, will dispose all provided disposables.
+     */
+    static from(...disposableLikes: { dispose: () => any }[]): Disposable;
+
+    /**
+     * Creates a new disposable that calls the provided function on dispose.
+     * *Note* that an asynchronous function is not awaited.
+     *
+     * @param callOnDispose Function that disposes something.
+     */
+    constructor(callOnDispose: () => any);
+
+    /**
+     * Dispose this object.
+     */
+    dispose(): any;
 }


### PR DESCRIPTION
This PR supports app start, app terminate, pre invocation, and post invocation hooks. Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/7

To see example code, check out the end-to-end tests I added [here](https://github.com/Azure/azure-functions-nodejs-e2e-tests/pull/26) in `app/v4/src/index.ts`. I also added unit tests in this repo, but they're less meaningful (they mainly ensure hooks are unit-testable by our users as well).

Loosely based off Hossam's work in https://github.com/Azure/azure-functions-nodejs-library/pull/115, which has been delayed a lot. I think part of the delay was from feature-creep, so my focus is just to get the MVP out and I don't have any plans to add all the [extra features](https://github.com/Azure/azure-functions-nodejs-library/issues?q=is%3Aopen+is%3Aissue+label%3Ahooks) at this time. I'm super excited about hooks even in MVP-form and I think our users will be, too.