### PR TITLE
Fix bug when using shared output object

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -164,8 +164,7 @@ export function generic(name: string, options: GenericFunctionOptions): void {
     }
 
     if (options.return) {
-        options.return.name = returnBindingKey;
-        bindings[options.return.name] = {
+        bindings[returnBindingKey] = {
             ...options.return,
             direction: 'out',
         };


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/179

### Repro steps:

1. Have two functions triggered by the same thing
2. Create an output binding as a `const`
3. Use the _same_ output binding as the `return` in one function and as an `extraOutput` in the other

**Expected**: Both output bindings work
**Actual**: The `return` output binding works and the `extraOutput` one doesn't set the output

End-to-end test (with sample code) here: https://github.com/Azure/azure-functions-nodejs-e2e-tests/pull/30