### PR TITLE
Fix WarmupContext type name

### DIFF
--- a/types/warmup.d.ts
+++ b/types/warmup.d.ts
@@ -4,8 +4,8 @@
 import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
-export interface WarmupContextOptions {}
-export type WarmupHandler = (warmupContext: WarmupContextOptions, context: InvocationContext) => FunctionResult;
+export interface WarmupContext {}
+export type WarmupHandler = (warmupContext: WarmupContext, context: InvocationContext) => FunctionResult;
 
 export interface WarmupFunctionOptions extends WarmupTriggerOptions, Partial<FunctionOptions> {
     handler: WarmupHandler;


### PR DESCRIPTION
This PR is a fix for [this discussion suggestion](https://github.com/Azure/azure-functions-nodejs-library/pull/180#discussion_r1378222069).

It is changing the name of the interface used for the `warmupContext` in warmup triggers from `WarmupContextOptions` to simply `WarmupContext`.