### PR TITLE
Add Resource Management Policy

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -11,40 +11,40 @@ configuration:
     - description: 
       frequencies:
       - hourly:
-          hour: 6
+          hour: 3
       filters:
       - isIssue
       - isOpen
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       - hasLabel:
           label: no recent activity
       - noActivitySince:
-          days: 7
+          days: 3
       actions:
       - closeIssue
     - description: 
       frequencies:
       - hourly:
-          hour: 6
+          hour: 3
       filters:
       - isIssue
       - isOpen
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       - noActivitySince:
-          days: 5
+          days: 4
       - isNotLabeledWith:
           label: no recent activity
       actions:
       - addLabel:
           label: no recent activity
       - addReply:
-          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **5 days**. It will be closed if no further activity occurs **within 2 days of this comment**.
+          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
     - description: 
       frequencies:
       - hourly:
-          hour: 6
+          hour: 3
       filters:
       - isIssue
       - isOpen
@@ -64,7 +64,7 @@ configuration:
       - isPullRequest
       - isOpen
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       - hasLabel:
           label: no recent activity
       - noActivitySince:
@@ -79,7 +79,7 @@ configuration:
       - isPullRequest
       - isOpen
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       - noActivitySince:
           days: 7
       - isNotLabeledWith:
@@ -97,12 +97,12 @@ configuration:
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       then:
       - addLabel:
-          label: 'needs-attention :wave:'
+          label: 'Needs: Attention :wave:'
       - removeLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Issues
@@ -120,10 +120,10 @@ configuration:
       - isAction:
           action: Closed
       - hasLabel:
-          label: needs-triage (functions)
+          label: 'Needs: Triage (Functions)'
       then:
       - removeLabel:
-          label: needs-triage (functions)
+          label: 'Needs: Triage (Functions)'
       description: 
     - if:
       - payloadType: Issue_Comment
@@ -141,7 +141,7 @@ configuration:
           reviewState: Changes_requested
       then:
       - addLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Pull_Request
@@ -151,30 +151,30 @@ configuration:
           isAction:
             action: Closed
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Issue_Comment
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Pull_Request_Review
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: needs-author feedback
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Pull_Request
@@ -219,4 +219,4 @@ configuration:
       - disableAutoMerge
       description: 
 onFailure: 
-onSuccess:
+onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,0 +1,222 @@
+id: 
+name: GitOps.PullRequestIssueManagement
+description: GitOps.PullRequestIssueManagement primitive
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: needs-author feedback
+      - hasLabel:
+          label: no recent activity
+      - noActivitySince:
+          days: 7
+      actions:
+      - closeIssue
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: needs-author feedback
+      - noActivitySince:
+          days: 5
+      - isNotLabeledWith:
+          label: no recent activity
+      actions:
+      - addLabel:
+          label: no recent activity
+      - addReply:
+          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **5 days**. It will be closed if no further activity occurs **within 2 days of this comment**.
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: duplicate
+      - noActivitySince:
+          days: 3
+      actions:
+      - addReply:
+          reply: This issue has been marked as duplicate and has not had any activity for **3 days**. It will be closed for housekeeping purposes.
+      - closeIssue
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 3
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: needs-author feedback
+      - hasLabel:
+          label: no recent activity
+      - noActivitySince:
+          days: 7
+      actions:
+      - closeIssue
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 3
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: needs-author feedback
+      - noActivitySince:
+          days: 7
+      - isNotLabeledWith:
+          label: no recent activity
+      actions:
+      - addLabel:
+          label: no recent activity
+      - addReply:
+          reply: This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
+    eventResponderTasks:
+    - if:
+      - payloadType: Issue_Comment
+      - isAction:
+          action: Created
+      - isActivitySender:
+          issueAuthor: True
+      - hasLabel:
+          label: needs-author feedback
+      then:
+      - addLabel:
+          label: 'needs-attention :wave:'
+      - removeLabel:
+          label: needs-author feedback
+      description: 
+    - if:
+      - payloadType: Issues
+      - not:
+          isAction:
+            action: Closed
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+      description: 
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Closed
+      - hasLabel:
+          label: needs-triage (functions)
+      then:
+      - removeLabel:
+          label: needs-triage (functions)
+      description: 
+    - if:
+      - payloadType: Issue_Comment
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+      description: 
+    - if:
+      - payloadType: Pull_Request_Review
+      - isAction:
+          action: Submitted
+      - isReviewState:
+          reviewState: Changes_requested
+      then:
+      - addLabel:
+          label: needs-author feedback
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - isActivitySender:
+          issueAuthor: True
+      - not:
+          isAction:
+            action: Closed
+      - hasLabel:
+          label: needs-author feedback
+      then:
+      - removeLabel:
+          label: needs-author feedback
+      description: 
+    - if:
+      - payloadType: Issue_Comment
+      - isActivitySender:
+          issueAuthor: True
+      - hasLabel:
+          label: needs-author feedback
+      then:
+      - removeLabel:
+          label: needs-author feedback
+      description: 
+    - if:
+      - payloadType: Pull_Request_Review
+      - isActivitySender:
+          issueAuthor: True
+      - hasLabel:
+          label: needs-author feedback
+      then:
+      - removeLabel:
+          label: needs-author feedback
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - not:
+          isAction:
+            action: Closed
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+      description: 
+    - if:
+      - payloadType: Issue_Comment
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+      description: 
+    - if:
+      - payloadType: Pull_Request_Review
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - hasLabel:
+          label: auto merge
+      then:
+      - enableAutoMerge:
+          mergeMethod: Squash
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - labelRemoved:
+          label: auto merge
+      then:
+      - disableAutoMerge
+      description: 
+onFailure: 
+onSuccess:


### PR DESCRIPTION
This PR is adding a Resource Management Policy. Previously, the work done by these policies was performed by Fabric Bot, but that service was deprecated earlier this year.

More information about Fabric Bot and its replacement can be found [here](https://docs.opensource.microsoft.com/tools/fabric-bot/) (this link will only be accessible to Microsoft employees).