### PR TITLE
Enable noImplicitAny option

### DIFF
--- a/src/converters/fromRpcNullable.ts
+++ b/src/converters/fromRpcNullable.ts
@@ -7,7 +7,7 @@ export function fromNullableMapping(
     nullableMapping: Record<string, RpcNullableString> | null | undefined,
     originalMapping?: Record<string, string> | null
 ): Record<string, string> {
-    let converted = {};
+    let converted: Record<string, string> = {};
     if (nullableMapping && Object.keys(nullableMapping).length > 0) {
         for (const key in nullableMapping) {
             converted[key] = nullableMapping[key].value || '';

--- a/src/converters/toCamelCase.ts
+++ b/src/converters/toCamelCase.ts
@@ -7,7 +7,7 @@ export function toCamelCaseValue(data: unknown): unknown {
     } else if (Array.isArray(data)) {
         return data.map(toCamelCaseValue);
     } else {
-        const result: Record<string, any> = {};
+        const result: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(data)) {
             result[toCamelCaseKey(key)] = toCamelCaseValue(value);
         }

--- a/src/converters/toCamelCase.ts
+++ b/src/converters/toCamelCase.ts
@@ -7,7 +7,7 @@ export function toCamelCaseValue(data: unknown): unknown {
     } else if (Array.isArray(data)) {
         return data.map(toCamelCaseValue);
     } else {
-        const result = {};
+        const result: Record<string, any> = {};
         for (const [key, value] of Object.entries(data)) {
             result[toCamelCaseKey(key)] = toCamelCaseValue(value);
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
-        "noImplicitAny": false,
         "strict": true,
         "noUnusedLocals": true,
         "outDir": "out",


### PR DESCRIPTION
Currently,  `noImplicitAny` is set to `false`. In general, this setting should be turned on, but I know it is useful for codebases transitioning from non-typed JavaScript to TypeScript.

When I checked how much work was needed to set `noImplicitAny` to `true`, I found that there were only two errors:

```
ERROR in ./src/converters/fromRpcNullable.ts:13:13
TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
  No index signature with a parameter of type 'string' was found on type '{}'.
    11 |     if (nullableMapping && Object.keys(nullableMapping).length > 0) {
    12 |         for (const key in nullableMapping) {
  > 13 |             converted[key] = nullableMapping[key].value || '';
       |             ^^^^^^^^^^^^^^
    14 |         }
    15 |     } else if (originalMapping && Object.keys(originalMapping).length > 0) {
    16 |         converted = originalMapping;

ERROR in ./src/converters/toCamelCase.ts:12:13
TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
  No index signature with a parameter of type 'string' was found on type '{}'.
    10 |         const result = {};
    11 |         for (const [key, value] of Object.entries(data)) {
  > 12 |             result[toCamelCaseKey(key)] = toCamelCaseValue(value);
       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    13 |         }
    14 |         return result;
    15 |     }

```

This PR addresses these two errors and sets  `noImplicitAny` to `true` (this is the default when `strict` is `true`).