### PR TITLE
Add support for request & response clone

### DIFF
--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -27,11 +27,11 @@ export class HttpRequest implements types.HttpRequest {
     constructor(init: InternalHttpRequestInit) {
         this.#init = init;
 
-        const url = nonNullProp(init, 'url');
-
         if (init.undiciRequest) {
             this.#uReq = init.undiciRequest;
         } else {
+            const url = nonNullProp(init, 'url');
+
             let body: Buffer | string | undefined;
             if (init.body?.bytes) {
                 body = Buffer.from(init.body?.bytes);

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -12,31 +12,42 @@ import { fromNullableMapping } from '../converters/fromRpcNullable';
 import { nonNullProp } from '../utils/nonNull';
 import { extractHttpUserFromHeaders } from './extractHttpUserFromHeaders';
 
+interface InternalHttpRequestInit extends RpcHttpData {
+    undiciRequest?: uRequest;
+}
+
 export class HttpRequest implements types.HttpRequest {
     readonly query: URLSearchParams;
     readonly params: HttpRequestParams;
 
     #cachedUser?: HttpRequestUser | null;
     #uReq: uRequest;
-    #body?: Buffer | string;
+    #init: InternalHttpRequestInit;
 
-    constructor(rpcHttp: RpcHttpData) {
-        const url = nonNullProp(rpcHttp, 'url');
+    constructor(init: InternalHttpRequestInit) {
+        this.#init = init;
 
-        if (rpcHttp.body?.bytes) {
-            this.#body = Buffer.from(rpcHttp.body?.bytes);
-        } else if (rpcHttp.body?.string) {
-            this.#body = rpcHttp.body.string;
+        const url = nonNullProp(init, 'url');
+
+        if (init.undiciRequest) {
+            this.#uReq = init.undiciRequest;
+        } else {
+            let body: Buffer | string | undefined;
+            if (init.body?.bytes) {
+                body = Buffer.from(init.body?.bytes);
+            } else if (init.body?.string) {
+                body = init.body.string;
+            }
+
+            this.#uReq = new uRequest(url, {
+                body,
+                method: nonNullProp(init, 'method'),
+                headers: fromNullableMapping(init.nullableHeaders, init.headers),
+            });
         }
 
-        this.#uReq = new uRequest(url, {
-            body: this.#body,
-            method: nonNullProp(rpcHttp, 'method'),
-            headers: fromNullableMapping(rpcHttp.nullableHeaders, rpcHttp.headers),
-        });
-
-        this.query = new URLSearchParams(fromNullableMapping(rpcHttp.nullableQuery, rpcHttp.query));
-        this.params = fromNullableMapping(rpcHttp.nullableParams, rpcHttp.params);
+        this.query = new URLSearchParams(fromNullableMapping(init.nullableQuery, init.query));
+        this.params = fromNullableMapping(init.nullableParams, init.params);
     }
 
     get url(): string {
@@ -85,5 +96,11 @@ export class HttpRequest implements types.HttpRequest {
 
     async text(): Promise<string> {
         return this.#uReq.text();
+    }
+
+    clone(): HttpRequest {
+        const newInit = structuredClone(this.#init);
+        newInit.undiciRequest = this.#uReq.clone();
+        return new HttpRequest(newInit);
     }
 }

--- a/test/http/HttpRequest.test.ts
+++ b/test/http/HttpRequest.test.ts
@@ -11,6 +11,34 @@ import { HttpRequest } from '../../src/http/HttpRequest';
 chai.use(chaiAsPromised);
 
 describe('HttpRequest', () => {
+    it('clone', async () => {
+        const req = new HttpRequest({
+            method: 'POST',
+            url: 'http://localhost:7071/api/helloWorld',
+            body: {
+                string: 'body1',
+            },
+            headers: {
+                a: 'b',
+            },
+            params: {
+                c: 'd',
+            },
+            query: {
+                e: 'f',
+            },
+        });
+        const req2 = req.clone();
+        expect(await req.text()).to.equal('body1');
+        expect(await req2.text()).to.equal('body1');
+        expect(req.headers).to.not.equal(req2.headers);
+        expect(req.headers).to.deep.equal(req2.headers);
+        expect(req.params).to.not.equal(req2.params);
+        expect(req.params).to.deep.equal(req2.params);
+        expect(req.query).to.not.equal(req2.query);
+        expect(req.query).to.deep.equal(req2.query);
+    });
+
     describe('formData', () => {
         const multipartContentType = 'multipart/form-data; boundary=----WebKitFormBoundaryeJGMO2YP65ZZXRmv';
         function createFormRequest(data: string, contentType: string = multipartContentType): HttpRequest {

--- a/test/http/HttpRequest.test.ts
+++ b/test/http/HttpRequest.test.ts
@@ -31,10 +31,13 @@ describe('HttpRequest', () => {
         const req2 = req.clone();
         expect(await req.text()).to.equal('body1');
         expect(await req2.text()).to.equal('body1');
+
         expect(req.headers).to.not.equal(req2.headers);
         expect(req.headers).to.deep.equal(req2.headers);
+
         expect(req.params).to.not.equal(req2.params);
         expect(req.params).to.deep.equal(req2.params);
+
         expect(req.query).to.not.equal(req2.query);
         expect(req.query).to.deep.equal(req2.query);
     });

--- a/test/http/HttpResponse.test.ts
+++ b/test/http/HttpResponse.test.ts
@@ -26,8 +26,10 @@ describe('HttpResponse', () => {
         const res2 = res.clone();
         expect(await res.text()).to.equal('body1');
         expect(await res2.text()).to.equal('body1');
+
         expect(res.headers).to.not.equal(res2.headers);
         expect(res.headers).to.deep.equal(res2.headers);
+
         expect(res.cookies).to.not.equal(res2.cookies);
         expect(res.cookies).to.deep.equal(res2.cookies);
     });

--- a/test/http/HttpResponse.test.ts
+++ b/test/http/HttpResponse.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import * as chai from 'chai';
+import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { HttpResponse } from '../../src/http/HttpResponse';
+
+chai.use(chaiAsPromised);
+
+describe('HttpResponse', () => {
+    it('clone', async () => {
+        const res = new HttpResponse({
+            body: 'body1',
+            headers: {
+                a: 'b',
+            },
+            cookies: [
+                {
+                    name: 'name1',
+                    value: 'value1',
+                },
+            ],
+        });
+        const res2 = res.clone();
+        expect(await res.text()).to.equal('body1');
+        expect(await res2.text()).to.equal('body1');
+        expect(res.headers).to.not.equal(res2.headers);
+        expect(res.headers).to.deep.equal(res2.headers);
+        expect(res.cookies).to.not.equal(res2.cookies);
+        expect(res.cookies).to.deep.equal(res2.cookies);
+    });
+});

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -145,6 +145,12 @@ export declare class HttpRequest {
      * Returns a promise fulfilled with the body as a string
      */
     readonly text: () => Promise<string>;
+
+    /**
+     * Creates a copy of the request object, with special handling of the body.
+     * [Learn more here](https://developer.mozilla.org/docs/Web/API/Request/clone)
+     */
+    readonly clone: () => HttpRequest;
 }
 
 /**
@@ -293,6 +299,12 @@ export declare class HttpResponse {
      * Returns a promise fulfilled with the body as a string
      */
     readonly text: () => Promise<string>;
+
+    /**
+     * Creates a copy of the response object, with special handling of the body.
+     * [Learn more here](https://developer.mozilla.org/docs/Web/API/Response/clone)
+     */
+    readonly clone: () => HttpResponse;
 }
 
 /**
@@ -368,7 +380,7 @@ export interface HttpRequestBodyInit {
     bytes?: Uint8Array;
 
     /**
-     * The body as a buffer. You only need to specify one of the `bytes` or `string` properties
+     * The body as a string. You only need to specify one of the `bytes` or `string` properties
      */
     string?: string;
 }


### PR DESCRIPTION
Just mirroring the existing "clone" methods already supported in undici/fetch. Per [the docs](https://developer.mozilla.org/en-US/docs/Web/API/Request/clone), "the main reason clone() exists is to allow multiple uses of body objects (when they are one-use only.)"

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/207