### PR TITLE
Http stream support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
             "version": "4.1.0",
             "license": "MIT",
             "dependencies": {
+                "cookie": "^0.6.0",
                 "long": "^4.0.0",
                 "undici": "^5.13.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
                 "@types/chai-as-promised": "^7.1.5",
+                "@types/cookie": "^0.6.0",
                 "@types/fs-extra": "^9.0.13",
                 "@types/long": "^4.0.2",
                 "@types/minimist": "^1.2.2",
@@ -345,6 +347,12 @@
             "dependencies": {
                 "@types/chai": "*"
             }
+        },
+        "node_modules/@types/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+            "dev": true
         },
         "node_modules/@types/eslint": {
             "version": "8.4.2",
@@ -1398,6 +1406,14 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "node_modules/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
@@ -5833,6 +5849,12 @@
                 "@types/chai": "*"
             }
         },
+        "@types/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+            "dev": true
+        },
         "@types/eslint": {
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -6621,6 +6643,11 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
         },
         "cosmiconfig": {
             "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
         "watch": "webpack --watch --mode development"
     },
     "dependencies": {
+        "cookie": "^0.6.0",
         "long": "^4.0.0",
         "undici": "^5.13.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",
         "@types/chai-as-promised": "^7.1.5",
+        "@types/cookie": "^0.6.0",
         "@types/fs-extra": "^9.0.13",
         "@types/long": "^4.0.2",
         "@types/minimist": "^1.2.2",

--- a/src/InvocationContext.ts
+++ b/src/InvocationContext.ts
@@ -10,6 +10,7 @@ import {
     TraceContext,
     TriggerMetadata,
 } from '@azure/functions';
+import { fallbackLogHandler } from './utils/fallbackLogHandler';
 
 export class InvocationContext implements types.InvocationContext {
     invocationId: string;
@@ -90,28 +91,5 @@ class InvocationContextExtraOutputs implements types.InvocationContextExtraOutpu
     set(outputOrName: types.FunctionOutput | string, value: unknown): void {
         const name = typeof outputOrName === 'string' ? outputOrName : outputOrName.name;
         this.#outputs[name] = value;
-    }
-}
-
-function fallbackLogHandler(level: types.LogLevel, ...args: unknown[]): void {
-    switch (level) {
-        case 'trace':
-            console.trace(...args);
-            break;
-        case 'debug':
-            console.debug(...args);
-            break;
-        case 'information':
-            console.info(...args);
-            break;
-        case 'warning':
-            console.warn(...args);
-            break;
-        case 'critical':
-        case 'error':
-            console.error(...args);
-            break;
-        default:
-            console.log(...args);
     }
 }

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -136,12 +136,12 @@ export class InvocationModel implements coreTypes.InvocationModel {
     }
 
     async #convertOutput(
-        invocId: string,
+        invocationId: string,
         binding: RpcBindingInfo,
         value: unknown
     ): Promise<RpcTypedData | null | undefined> {
         if (binding.type?.toLowerCase() === 'http') {
-            return toRpcHttp(invocId, value);
+            return toRpcHttp(invocationId, value);
         } else {
             return toRpcTypedData(value);
         }

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -20,7 +20,7 @@ import { fromRpcTypedData } from './converters/fromRpcTypedData';
 import { toCamelCaseValue } from './converters/toCamelCase';
 import { toRpcHttp } from './converters/toRpcHttp';
 import { toRpcTypedData } from './converters/toRpcTypedData';
-import { waitForRequest } from './http/httpProxy';
+import { waitForProxyRequest } from './http/httpProxy';
 import { HttpRequest } from './http/HttpRequest';
 import { InvocationContext } from './InvocationContext';
 import { isHttpStreamEnabled } from './setup';
@@ -68,7 +68,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
 
                 let input: unknown;
                 if (isHttpTrigger(bindingType) && isHttpStreamEnabled()) {
-                    const proxyRequest = await waitForRequest(this.#coreCtx.invocationId);
+                    const proxyRequest = await waitForProxyRequest(this.#coreCtx.invocationId);
                     input = new HttpRequest({ ...binding.data?.http, proxyRequest });
                 } else {
                     input = fromRpcTypedData(binding.data);

--- a/src/ProgrammingModel.ts
+++ b/src/ProgrammingModel.ts
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as coreTypes from '@azure/functions-core';
+import { CoreInvocationContext, WorkerCapabilities } from '@azure/functions-core';
+import { version } from './constants';
+import { setupHttpProxy } from './http/httpProxy';
+import { InvocationModel } from './InvocationModel';
+import { isHttpStreamEnabled, lockSetup } from './setup';
+
+export class ProgrammingModel implements coreTypes.ProgrammingModel {
+    name = '@azure/functions';
+    version = version;
+
+    getInvocationModel(coreCtx: CoreInvocationContext): InvocationModel {
+        return new InvocationModel(coreCtx);
+    }
+
+    async getCapabilities(capabilities: WorkerCapabilities): Promise<WorkerCapabilities> {
+        lockSetup();
+
+        if (isHttpStreamEnabled()) {
+            const httpUri = await setupHttpProxy();
+            capabilities.HttpUri = httpUri;
+        }
+
+        return capabilities;
+    }
+}

--- a/src/addBindingName.ts
+++ b/src/addBindingName.ts
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export { HttpRequest } from './http/HttpRequest';
-export { HttpResponse } from './http/HttpResponse';
-export { InvocationContext } from './InvocationContext';
-
 const bindingCounts: Record<string, number> = {};
 /**
  * If the host spawns multiple workers, it expects the metadata (including binding name) to be the same across workers.

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,27 +22,20 @@ import {
     WarmupFunctionOptions,
 } from '@azure/functions';
 import * as coreTypes from '@azure/functions-core';
-import { CoreInvocationContext, FunctionCallback } from '@azure/functions-core';
-import { returnBindingKey, version } from './constants';
+import { FunctionCallback } from '@azure/functions-core';
+import { returnBindingKey } from './constants';
 import { toRpcDuration } from './converters/toRpcDuration';
-import { InvocationModel } from './InvocationModel';
 import * as output from './output';
+import { ProgrammingModel } from './ProgrammingModel';
 import * as trigger from './trigger';
 import { isTrigger } from './utils/isTrigger';
 import { tryGetCoreApiLazy } from './utils/tryGetCoreApiLazy';
 
 export * as hook from './hooks/registerHook';
+export { setup } from './setup';
 
-class ProgrammingModel implements coreTypes.ProgrammingModel {
-    name = '@azure/functions';
-    version = version;
-    getInvocationModel(coreCtx: CoreInvocationContext): InvocationModel {
-        return new InvocationModel(coreCtx);
-    }
-}
-
-let hasSetup = false;
-function setup() {
+let hasSetModel = false;
+function setProgrammingModel() {
     const coreApi = tryGetCoreApiLazy();
     if (!coreApi) {
         console.warn(
@@ -51,7 +44,7 @@ function setup() {
     } else {
         coreApi.setProgrammingModel(new ProgrammingModel());
     }
-    hasSetup = true;
+    hasSetModel = true;
 }
 
 function convertToHttpOptions(
@@ -141,8 +134,8 @@ export function warmup(name: string, options: WarmupFunctionOptions): void {
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {
-    if (!hasSetup) {
-        setup();
+    if (!hasSetModel) {
+        setProgrammingModel();
     }
 
     const bindings: Record<string, coreTypes.RpcBindingInfo> = {};

--- a/src/converters/toRpcHttp.ts
+++ b/src/converters/toRpcHttp.ts
@@ -3,7 +3,7 @@
 
 import { RpcHttpData, RpcTypedData } from '@azure/functions-core';
 import { AzFuncSystemError } from '../errors';
-import { sendResponse } from '../http/httpProxy';
+import { sendProxyResponse } from '../http/httpProxy';
 import { HttpResponse } from '../http/HttpResponse';
 import { isHttpStreamEnabled } from '../setup';
 import { toRpcHttpCookie } from './toRpcHttpCookie';
@@ -20,8 +20,9 @@ export async function toRpcHttp(invocationId: string, data: unknown): Promise<Rp
 
     const response = data instanceof HttpResponse ? data : new HttpResponse(data);
     if (isHttpStreamEnabled()) {
-        await sendResponse(invocationId, response);
-        return undefined;
+        // send http data over http proxy instead of rpc
+        await sendProxyResponse(invocationId, response);
+        return;
     }
 
     const rpcResponse: RpcHttpData = {};

--- a/src/converters/toRpcHttp.ts
+++ b/src/converters/toRpcHttp.ts
@@ -9,7 +9,7 @@ import { isHttpStreamEnabled } from '../setup';
 import { toRpcHttpCookie } from './toRpcHttpCookie';
 import { toRpcTypedData } from './toRpcTypedData';
 
-export async function toRpcHttp(invocId: string, data: unknown): Promise<RpcTypedData | null | undefined> {
+export async function toRpcHttp(invocationId: string, data: unknown): Promise<RpcTypedData | null | undefined> {
     if (data === null || data === undefined) {
         return data;
     } else if (typeof data !== 'object') {
@@ -20,7 +20,7 @@ export async function toRpcHttp(invocId: string, data: unknown): Promise<RpcType
 
     const response = data instanceof HttpResponse ? data : new HttpResponse(data);
     if (isHttpStreamEnabled()) {
-        await sendResponse(invocId, response);
+        await sendResponse(invocationId, response);
         return undefined;
     }
 

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -5,15 +5,19 @@ import * as types from '@azure/functions';
 import { HttpRequestParams, HttpRequestUser } from '@azure/functions';
 import { RpcHttpData } from '@azure/functions-core';
 import { Blob } from 'buffer';
+import { IncomingMessage } from 'http';
+import * as stream from 'stream';
 import { ReadableStream } from 'stream/web';
 import { FormData, Headers, Request as uRequest } from 'undici';
 import { URLSearchParams } from 'url';
 import { fromNullableMapping } from '../converters/fromRpcNullable';
+import { AzFuncSystemError } from '../errors';
 import { nonNullProp } from '../utils/nonNull';
 import { extractHttpUserFromHeaders } from './extractHttpUserFromHeaders';
 
 interface InternalHttpRequestInit extends RpcHttpData {
     undiciRequest?: uRequest;
+    proxyRequest?: IncomingMessage;
 }
 
 export class HttpRequest implements types.HttpRequest {
@@ -27,9 +31,16 @@ export class HttpRequest implements types.HttpRequest {
     constructor(init: InternalHttpRequestInit) {
         this.#init = init;
 
-        if (init.undiciRequest) {
-            this.#uReq = init.undiciRequest;
+        if (init.proxyRequest) {
+            [this.#uReq, this.query, this.params] = this.#initStreamRequest(init);
         } else {
+            [this.#uReq, this.query, this.params] = this.#initInMemoryRequest(init);
+        }
+    }
+
+    #initInMemoryRequest(init: InternalHttpRequestInit): [uRequest, URLSearchParams, HttpRequestParams] {
+        let uReq = init.undiciRequest;
+        if (!uReq) {
             const url = nonNullProp(init, 'url');
 
             let body: Buffer | string | undefined;
@@ -39,15 +50,51 @@ export class HttpRequest implements types.HttpRequest {
                 body = init.body.string;
             }
 
-            this.#uReq = new uRequest(url, {
+            uReq = new uRequest(url, {
                 body,
                 method: nonNullProp(init, 'method'),
                 headers: fromNullableMapping(init.nullableHeaders, init.headers),
             });
         }
 
-        this.query = new URLSearchParams(fromNullableMapping(init.nullableQuery, init.query));
-        this.params = fromNullableMapping(init.nullableParams, init.params);
+        const query = new URLSearchParams(fromNullableMapping(init.nullableQuery, init.query));
+        const params = fromNullableMapping(init.nullableParams, init.params);
+
+        return [uReq, query, params];
+    }
+
+    #initStreamRequest(init: InternalHttpRequestInit): [uRequest, URLSearchParams, HttpRequestParams] {
+        const proxyReq = nonNullProp(init, 'proxyRequest');
+
+        const hostHeaderName = 'x-forwarded-host';
+        const protoHeaderName = 'x-forwarded-proto';
+        const host = proxyReq.headers[hostHeaderName];
+        const proto = proxyReq.headers[protoHeaderName];
+        if (typeof host !== 'string' || typeof proto !== 'string') {
+            throw new AzFuncSystemError(`Expected headers "${hostHeaderName}" and "${protoHeaderName}" to be set.`);
+        }
+        const url = `${proto}://${host}${nonNullProp(proxyReq, 'url')}`;
+
+        let uReq = init.undiciRequest;
+        if (!uReq) {
+            let body: stream.Readable | undefined;
+            const lowerMethod = proxyReq.method?.toLowerCase();
+            if (lowerMethod !== 'get' && lowerMethod !== 'head') {
+                body = proxyReq;
+            }
+
+            uReq = new uRequest(url, {
+                body: body,
+                duplex: 'half',
+                method: nonNullProp(proxyReq, 'method'),
+                headers: <Record<string, string | ReadonlyArray<string>>>proxyReq.headers,
+            });
+        }
+
+        const query = new URL(url).searchParams;
+        const params = fromNullableMapping(init.nullableParams, init.params);
+
+        return [uReq, query, params];
     }
 
     get url(): string {

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -20,6 +20,8 @@ interface InternalHttpRequestInit extends RpcHttpData {
     proxyRequest?: IncomingMessage;
 }
 
+type RequestInitResult = [uRequest, URLSearchParams, HttpRequestParams];
+
 export class HttpRequest implements types.HttpRequest {
     readonly query: URLSearchParams;
     readonly params: HttpRequestParams;
@@ -38,7 +40,7 @@ export class HttpRequest implements types.HttpRequest {
         }
     }
 
-    #initInMemoryRequest(init: InternalHttpRequestInit): [uRequest, URLSearchParams, HttpRequestParams] {
+    #initInMemoryRequest(init: InternalHttpRequestInit): RequestInitResult {
         let uReq = init.undiciRequest;
         if (!uReq) {
             const url = nonNullProp(init, 'url');
@@ -63,7 +65,7 @@ export class HttpRequest implements types.HttpRequest {
         return [uReq, query, params];
     }
 
-    #initStreamRequest(init: InternalHttpRequestInit): [uRequest, URLSearchParams, HttpRequestParams] {
+    #initStreamRequest(init: InternalHttpRequestInit): RequestInitResult {
         const proxyReq = nonNullProp(init, 'proxyRequest');
 
         const hostHeaderName = 'x-forwarded-host';

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { serialize as serializeCookie } from 'cookie';
+import { EventEmitter } from 'events';
+import * as http from 'http';
+import { AzFuncSystemError, ensureErrorType } from '../errors';
+import { nonNullProp } from '../utils/nonNull';
+import { workerSystemLog } from '../utils/workerSystemLog';
+import { HttpResponse } from './HttpResponse';
+
+const requests: Record<string, http.IncomingMessage> = {};
+const responses: Record<string, http.ServerResponse> = {};
+
+const invocRequestEmitter = new EventEmitter();
+
+export async function waitForRequest(invocId: string): Promise<http.IncomingMessage> {
+    return new Promise((resolve, _reject) => {
+        const req = requests[invocId];
+        if (req) {
+            resolve(req);
+            delete requests[invocId];
+        } else {
+            invocRequestEmitter.once(invocId, () => {
+                const req = requests[invocId];
+                if (req) {
+                    resolve(req);
+                    delete requests[invocId];
+                }
+            });
+        }
+    });
+}
+
+const invocIdHeader = 'x-ms-invocation-id';
+export async function sendResponse(invocId: string, userRes: HttpResponse): Promise<void> {
+    const proxyRes = nonNullProp(responses, invocId);
+    delete responses[invocId];
+    for (const [key, val] of userRes.headers.entries()) {
+        proxyRes.setHeader(key, val);
+    }
+    proxyRes.setHeader(invocIdHeader, invocId);
+    proxyRes.statusCode = userRes.status;
+
+    if (userRes.cookies.length > 0) {
+        setCookies(userRes, proxyRes);
+    }
+
+    if (userRes.body) {
+        for await (const chunk of userRes.body.values()) {
+            proxyRes.write(chunk);
+        }
+    }
+    proxyRes.end();
+}
+
+function setCookies(userRes: HttpResponse, proxyRes: http.ServerResponse): void {
+    const serializedCookies: string[] = userRes.cookies.map((c) => {
+        let sameSite: true | false | 'lax' | 'strict' | 'none' | undefined;
+        switch (c.sameSite) {
+            case 'Lax':
+                sameSite = 'lax';
+                break;
+            case 'None':
+                sameSite = 'none';
+                break;
+            case 'Strict':
+                sameSite = 'strict';
+                break;
+            default:
+                sameSite = c.sameSite;
+        }
+        return serializeCookie(c.name, c.value, {
+            domain: c.domain,
+            path: c.path,
+            expires: typeof c.expires === 'number' ? new Date(c.expires) : c.expires,
+            secure: c.secure,
+            httpOnly: c.httpOnly,
+            sameSite: sameSite,
+            maxAge: c.maxAge,
+        });
+    });
+    proxyRes.setHeader('Set-Cookie', serializedCookies);
+}
+
+export async function setupHttpProxy(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const server = http.createServer();
+
+        server.on('request', (req, res) => {
+            const invocId = req.headers[invocIdHeader];
+            if (typeof invocId === 'string') {
+                requests[invocId] = req;
+                responses[invocId] = res;
+                invocRequestEmitter.emit(invocId);
+            } else {
+                workerSystemLog('error', `Http proxy request missing header ${invocIdHeader}`);
+            }
+        });
+
+        server.on('error', (err) => {
+            err = ensureErrorType(err);
+            workerSystemLog('error', `Http proxy error: ${err.stack || err.message}`);
+        });
+
+        server.listen(() => {
+            const address = server.address();
+            if (address !== null && typeof address === 'object') {
+                resolve(`http://localhost:${address.port}/`);
+            } else {
+                reject(new AzFuncSystemError('Unexpected server address during http proxy setup'));
+            }
+        });
+
+        server.on('close', () => {
+            workerSystemLog('information', 'Http proxy closing');
+        });
+    });
+}

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -14,7 +14,7 @@ const responses: Record<string, http.ServerResponse> = {};
 
 const invocRequestEmitter = new EventEmitter();
 
-export async function waitForRequest(invocationId: string): Promise<http.IncomingMessage> {
+export async function waitForProxyRequest(invocationId: string): Promise<http.IncomingMessage> {
     return new Promise((resolve, _reject) => {
         const req = requests[invocationId];
         if (req) {
@@ -33,7 +33,7 @@ export async function waitForRequest(invocationId: string): Promise<http.Incomin
 }
 
 const invocationIdHeader = 'x-ms-invocation-id';
-export async function sendResponse(invocationId: string, userRes: HttpResponse): Promise<void> {
+export async function sendProxyResponse(invocationId: string, userRes: HttpResponse): Promise<void> {
     const proxyRes = nonNullProp(responses, invocationId);
     delete responses[invocationId];
     for (const [key, val] of userRes.headers.entries()) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { SetupOptions } from '../types';
+import { AzFuncSystemError } from './errors';
+import { workerSystemLog } from './utils/workerSystemLog';
+
+let options: SetupOptions = {};
+let setupLocked = false;
+
+export function lockSetup(): void {
+    setupLocked = true;
+}
+
+export function setup(opts: SetupOptions): void {
+    if (setupLocked) {
+        throw new AzFuncSystemError("Setup options can't be changed after app startup has finished.");
+    }
+    options = opts;
+    workerSystemLog('information', `Setup options: ${JSON.stringify(options)}`);
+}
+
+export function isHttpStreamEnabled(): boolean {
+    return !!options.enableHttpStream;
+}

--- a/src/utils/fallbackLogHandler.ts
+++ b/src/utils/fallbackLogHandler.ts
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+
+export function fallbackLogHandler(level: types.LogLevel, ...args: unknown[]): void {
+    switch (level) {
+        case 'trace':
+            console.trace(...args);
+            break;
+        case 'debug':
+            console.debug(...args);
+            break;
+        case 'information':
+            console.info(...args);
+            break;
+        case 'warning':
+            console.warn(...args);
+            break;
+        case 'critical':
+        case 'error':
+            console.error(...args);
+            break;
+        default:
+            console.log(...args);
+    }
+}

--- a/src/utils/workerSystemLog.ts
+++ b/src/utils/workerSystemLog.ts
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as types from '@azure/functions';
+import { format } from 'util';
+import { fallbackLogHandler } from './fallbackLogHandler';
+import { tryGetCoreApiLazy } from './tryGetCoreApiLazy';
+
+export function workerSystemLog(level: types.LogLevel, ...args: unknown[]): void {
+    const coreApi = tryGetCoreApiLazy();
+    if (coreApi) {
+        coreApi.log(level, 'system', format(...args));
+    } else {
+        fallbackLogHandler(level, ...args);
+    }
+}

--- a/test/converters/toRpcHttp.test.ts
+++ b/test/converters/toRpcHttp.test.ts
@@ -29,24 +29,24 @@ describe('toRpcHttp', () => {
     }
 
     it('hello world', async () => {
-        const result = await toRpcHttp({ body: 'hello world' });
+        const result = await toRpcHttp('invocId', { body: 'hello world' });
         expect(result).to.deep.equal(getExpectedRpcHttp('hello world', textPlainHeaders));
     });
 
     it('response class hello world', async () => {
-        const result = await toRpcHttp(new HttpResponse({ body: 'hello world' }));
+        const result = await toRpcHttp('invocId', new HttpResponse({ body: 'hello world' }));
         expect(result).to.deep.equal(getExpectedRpcHttp('hello world', textPlainHeaders));
     });
 
     it('response class json', async () => {
-        const result = await toRpcHttp(new HttpResponse({ jsonBody: { hello: 'world' } }));
+        const result = await toRpcHttp('invocId', new HttpResponse({ jsonBody: { hello: 'world' } }));
         expect(result).to.deep.equal(getExpectedRpcHttp('{"hello":"world"}', jsonHeaders));
     });
 
     it('response class json manual json', async () => {
         const req = new HttpResponse({ body: '{ "hello":  "world" }' });
         req.headers.set('content-type', 'application/json');
-        const result = await toRpcHttp(req);
+        const result = await toRpcHttp('invocId', req);
         expect(result).to.deep.equal(
             getExpectedRpcHttp('{ "hello":  "world" }', {
                 'content-type': 'application/json',
@@ -55,49 +55,49 @@ describe('toRpcHttp', () => {
     });
 
     it('undefined', async () => {
-        const result = await toRpcHttp({});
+        const result = await toRpcHttp('invocId', {});
         expect(result).to.deep.equal(getExpectedRpcHttp('', {}));
     });
 
     it('array (weird, but still valid)', async () => {
-        const result = await toRpcHttp(Object.assign([], { body: 'a' }));
+        const result = await toRpcHttp('invocId', Object.assign([], { body: 'a' }));
         expect(result).to.deep.equal(getExpectedRpcHttp('a', textPlainHeaders));
     });
 
     it('invalid data string', async () => {
-        await expect(toRpcHttp('invalid')).to.eventually.be.rejectedWith(/must be an object/i);
+        await expect(toRpcHttp('invocId', 'invalid')).to.eventually.be.rejectedWith(/must be an object/i);
     });
 
     it('invalid data boolean', async () => {
-        await expect(toRpcHttp(true)).to.eventually.be.rejectedWith(/must be an object/i);
+        await expect(toRpcHttp('invocId', true)).to.eventually.be.rejectedWith(/must be an object/i);
     });
 
     it('body buffer', async () => {
-        const result = await toRpcHttp({ body: Buffer.from('b') });
+        const result = await toRpcHttp('invocId', { body: Buffer.from('b') });
         expect(result).to.deep.equal(getExpectedRpcHttp('b', {}));
     });
 
     it('body number', async () => {
-        const result = await toRpcHttp({ body: 3 });
+        const result = await toRpcHttp('invocId', { body: 3 });
         expect(result).to.deep.equal(getExpectedRpcHttp('3', textPlainHeaders));
     });
 
     it('status number', async () => {
-        const result = await toRpcHttp({ status: 400 });
+        const result = await toRpcHttp('invocId', { status: 400 });
         expect(result).to.deep.equal(getExpectedRpcHttp('', {}, '400'));
     });
 
     it('status string', async () => {
-        const result = await toRpcHttp({ status: '500' });
+        const result = await toRpcHttp('invocId', { status: '500' });
         expect(result).to.deep.equal(getExpectedRpcHttp('', {}, '500'));
     });
 
     it('status invalid', async () => {
-        await expect(toRpcHttp({ status: {} })).to.eventually.be.rejectedWith(/status/i);
+        await expect(toRpcHttp('invocId', { status: {} })).to.eventually.be.rejectedWith(/status/i);
     });
 
     it('headers object', async () => {
-        const result = await toRpcHttp({
+        const result = await toRpcHttp('invocId', {
             headers: {
                 a: 'b',
             },
@@ -106,14 +106,14 @@ describe('toRpcHttp', () => {
     });
 
     it('headers array', async () => {
-        const result = await toRpcHttp({
+        const result = await toRpcHttp('invocId', {
             headers: [['c', 'd']],
         });
         expect(result?.http?.headers?.c).to.equal('d');
     });
 
     it('headers class', async () => {
-        const result = await toRpcHttp({
+        const result = await toRpcHttp('invocId', {
             headers: new Headers({
                 e: 'f',
             }),
@@ -122,6 +122,8 @@ describe('toRpcHttp', () => {
     });
 
     it('headers invalid', async () => {
-        await expect(toRpcHttp({ headers: true })).to.eventually.be.rejectedWith(/argument.*could not be converted/i);
+        await expect(toRpcHttp('invocId', { headers: true })).to.eventually.be.rejectedWith(
+            /argument.*could not be converted/i
+        );
     });
 });

--- a/types-core/index.d.ts
+++ b/types-core/index.d.ts
@@ -22,7 +22,7 @@ declare module '@azure/functions-core' {
     function registerFunction(metadata: FunctionMetadata, callback: FunctionCallback): Disposable;
 
     /**
-     * A slimmed down version of `RpcFunctionMetadata` that includes the minimum amount of information needed to register a function
+     * A slimmed down version of `RpcFunctionMetadata` that includes only the properties respected as a part of the `registerFunction` api
      * NOTE: All properties on this object need to be deterministic to support the multiple worker scenario. More info here: https://github.com/Azure/azure-functions-nodejs-worker/issues/638
      */
     interface FunctionMetadata {
@@ -186,6 +186,12 @@ declare module '@azure/functions-core' {
     function getProgrammingModel(): ProgrammingModel;
 
     /**
+     * The recommended way to log information outside the context of an invocation
+     * During an invocation, use `CoreInvocationContext.log` instead
+     */
+    function log(level: RpcLogLevel, category: RpcLogCategory, message: string): void;
+
+    /**
      * A set of information and methods that describe the model for handling a Node.js function app
      * Currently, this is mainly focused on invocation
      */
@@ -203,8 +209,15 @@ declare module '@azure/functions-core' {
         /**
          * Returns a new instance of the invocation model for each invocation
          */
-        getInvocationModel(coreContext: CoreInvocationContext): InvocationModel;
+        getInvocationModel(coreContext: CoreInvocationContext): InvocationModel | Promise<InvocationModel>;
+
+        /**
+         * Optional method to modify worker capabilities
+         */
+        getCapabilities?(defaultCapabilities: WorkerCapabilities): WorkerCapabilities | Promise<WorkerCapabilities>;
     }
+
+    type WorkerCapabilities = Record<string, string>;
 
     /**
      * Basic information and helper methods about an invocation provided from the core worker to the programming model

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -7,9 +7,16 @@ import { EventHubFunctionOptions } from './eventHub';
 import { GenericFunctionOptions } from './generic';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
+import { SetupOptions } from './setup';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';
 import { WarmupFunctionOptions } from './warmup';
+
+/**
+ * Optional method to configure the behavior of your app.
+ * This can only be done during app startup, before invocations occur
+ */
+export declare function setup(options: SetupOptions): void;
 
 /**
  * Registers an http function in your app that will be triggered by making a request to the function url

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,6 +18,7 @@ export * as input from './input';
 export * from './InvocationContext';
 export * as output from './output';
 export * from './serviceBus';
+export * from './setup';
 export * from './sql';
 export * from './storage';
 export * from './table';

--- a/types/setup.d.ts
+++ b/types/setup.d.ts
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface SetupOptions {
+    /**
+     * PREVIEW: Stream http requests and responses instead of loading entire body in memory
+     */
+    enableHttpStream?: boolean;
+}


### PR DESCRIPTION
HTTP stream support should require minimal changes by the user. The only thing _required_ is turning on this flag:
```typescript
import { app } from '@azure/functions';

app.setup({ enableHttpStream: true });
```
Otherwise it's up to them to use the existing HTTP request/response types as streams instead of buffers.

I've added end-to-end tests here which can be used as sample code for now: https://github.com/Azure/azure-functions-nodejs-e2e-tests/pull/32

Lastly, the only known problem is that the `request.params` object will not be populated. Plenty of scenarios don't need this and users should be able to workaround the problem by parsing the url themselves, so I'd rather get this moving while we figure that specific feature out offline.

Depends on [v3.9.0 of the worker](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.9.0) which has finished rolling out in Azure with host v4.28, but we don't have an official core tools release yet.

Related to https://github.com/Azure/azure-functions-nodejs-library/issues/97
Related to https://github.com/Azure/azure-functions-nodejs-library/issues/171