### PR TITLE
Fix out-of-sync binding names causing null ref error

### DIFF
--- a/src/converters/toCoreFunctionMetadata.ts
+++ b/src/converters/toCoreFunctionMetadata.ts
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ExponentialBackoffRetryOptions, FixedDelayRetryOptions, GenericFunctionOptions } from '@azure/functions';
+import * as coreTypes from '@azure/functions-core';
+import { returnBindingKey } from '../constants';
+import { isTrigger } from '../utils/isTrigger';
+import { toRpcDuration } from './toRpcDuration';
+
+export function toCoreFunctionMetadata(name: string, options: GenericFunctionOptions): coreTypes.FunctionMetadata {
+    const bindings: Record<string, coreTypes.RpcBindingInfo> = {};
+
+    const trigger = options.trigger;
+    bindings[trigger.name] = {
+        ...trigger,
+        direction: 'in',
+        type: isTrigger(trigger.type) ? trigger.type : trigger.type + 'Trigger',
+    };
+
+    if (options.extraInputs) {
+        for (const input of options.extraInputs) {
+            bindings[input.name] = {
+                ...input,
+                direction: 'in',
+            };
+        }
+    }
+
+    if (options.return) {
+        bindings[returnBindingKey] = {
+            ...options.return,
+            direction: 'out',
+        };
+    }
+
+    if (options.extraOutputs) {
+        for (const output of options.extraOutputs) {
+            bindings[output.name] = {
+                ...output,
+                direction: 'out',
+            };
+        }
+    }
+
+    let retryOptions: coreTypes.RpcRetryOptions | undefined;
+    if (options.retry) {
+        retryOptions = {
+            ...options.retry,
+            retryStrategy: options.retry.strategy,
+            delayInterval: toRpcDuration((<FixedDelayRetryOptions>options.retry).delayInterval, 'retry.delayInterval'),
+            maximumInterval: toRpcDuration(
+                (<ExponentialBackoffRetryOptions>options.retry).maximumInterval,
+                'retry.maximumInterval'
+            ),
+            minimumInterval: toRpcDuration(
+                (<ExponentialBackoffRetryOptions>options.retry).minimumInterval,
+                'retry.minimumInterval'
+            ),
+        };
+    }
+
+    return { name, bindings, retryOptions };
+}

--- a/src/utils/getRandomHexString.ts
+++ b/src/utils/getRandomHexString.ts
@@ -7,3 +7,7 @@ export function getRandomHexString(length = 10): string {
     const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
     return buffer.toString('hex').slice(0, length);
 }
+
+export function getStringHash(data: string, length = 10): string {
+    return crypto.createHash('sha256').update(data).digest('hex').slice(0, length);
+}

--- a/test/converters/toCoreFunctionMetadata.test.ts
+++ b/test/converters/toCoreFunctionMetadata.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { output, trigger } from '../../src';
+import { toCoreFunctionMetadata } from '../../src/converters/toCoreFunctionMetadata';
+
+describe('toCoreFunctionMetadata', () => {
+    const handler = () => {};
+    const expectedHttpTrigger = {
+        authLevel: 'anonymous',
+        methods: ['GET', 'POST'],
+        type: 'httpTrigger',
+        name: 'httpTrigger433d175fc9',
+        direction: 'in',
+    };
+    const expectedHttpOutput = { type: 'http', name: 'httpOutput9a706511b1', direction: 'out' };
+    const expectedQueueOutput1 = {
+        queueName: 'e2e-test-queue-trigger',
+        connection: 'e2eTest_storage',
+        type: 'queue',
+        name: 'queueOutput8b95495f3d',
+        direction: 'out',
+    };
+
+    it('http trigger', () => {
+        const result = toCoreFunctionMetadata('funcName', {
+            handler,
+            trigger: trigger.http({}),
+            return: output.http({}),
+        });
+        expect(result).to.deep.equal({
+            name: 'funcName',
+            bindings: {
+                httpTrigger433d175fc9: expectedHttpTrigger,
+                $return: expectedHttpOutput,
+            },
+            retryOptions: undefined,
+        });
+    });
+
+    it('http trigger, storage output', () => {
+        const result = toCoreFunctionMetadata('funcName', {
+            handler,
+            trigger: trigger.http({}),
+            return: output.http({}),
+            extraOutputs: [
+                output.storageQueue({
+                    queueName: 'e2e-test-queue-trigger',
+                    connection: 'e2eTest_storage',
+                }),
+            ],
+        });
+        expect(result).to.deep.equal({
+            name: 'funcName',
+            bindings: {
+                httpTrigger433d175fc9: expectedHttpTrigger,
+                $return: expectedHttpOutput,
+                queueOutput8b95495f3d: expectedQueueOutput1,
+            },
+            retryOptions: undefined,
+        });
+    });
+
+    it('http trigger, multiple storage output', () => {
+        const result = toCoreFunctionMetadata('funcName', {
+            handler,
+            trigger: trigger.http({}),
+            return: output.http({}),
+            extraOutputs: [
+                output.storageQueue({
+                    queueName: 'e2e-test-queue-trigger',
+                    connection: 'e2eTest_storage',
+                }),
+                output.storageQueue({
+                    queueName: 'e2e-test-queue-trigger2',
+                    connection: 'e2eTest_storage',
+                }),
+            ],
+        });
+        expect(result).to.deep.equal({
+            name: 'funcName',
+            bindings: {
+                httpTrigger433d175fc9: expectedHttpTrigger,
+                $return: expectedHttpOutput,
+                queueOutput8b95495f3d: expectedQueueOutput1,
+                queueOutput7ab7ce64ad: {
+                    queueName: 'e2e-test-queue-trigger2',
+                    connection: 'e2eTest_storage',
+                    type: 'queue',
+                    name: 'queueOutput7ab7ce64ad',
+                    direction: 'out',
+                },
+            },
+            retryOptions: undefined,
+        });
+    });
+
+    it('http trigger, duplicate storage output', () => {
+        expect(() => {
+            toCoreFunctionMetadata('funcName', {
+                handler,
+                trigger: trigger.http({}),
+                return: output.http({}),
+                extraOutputs: [
+                    output.storageQueue({
+                        queueName: 'e2e-test-queue-trigger',
+                        connection: 'e2eTest_storage',
+                    }),
+                    output.storageQueue({
+                        queueName: 'e2e-test-queue-trigger',
+                        connection: 'e2eTest_storage',
+                    }),
+                ],
+            });
+        }).to.throw(/duplicate bindings found/i);
+    });
+
+    it('http trigger, duplicate storage output with name workaround', () => {
+        const result = toCoreFunctionMetadata('funcName', {
+            handler,
+            trigger: trigger.http({}),
+            return: output.http({}),
+            extraOutputs: [
+                output.storageQueue({
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    name: 'notADupe',
+                    queueName: 'e2e-test-queue-trigger',
+                    connection: 'e2eTest_storage',
+                }),
+                output.storageQueue({
+                    queueName: 'e2e-test-queue-trigger',
+                    connection: 'e2eTest_storage',
+                }),
+            ],
+        });
+
+        expect(result).to.deep.equal({
+            name: 'funcName',
+            bindings: {
+                httpTrigger433d175fc9: expectedHttpTrigger,
+                $return: expectedHttpOutput,
+                queueOutput8b95495f3d: expectedQueueOutput1,
+                notADupe: {
+                    queueName: 'e2e-test-queue-trigger',
+                    connection: 'e2eTest_storage',
+                    type: 'queue',
+                    name: 'notADupe',
+                    direction: 'out',
+                },
+            },
+            retryOptions: undefined,
+        });
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/210

The logs from the user indicate a mismatch in the binding name between the host and worker ("httpTrigger17" vs "httpTrigger19"). I suspect our logic in "addBindingName" isn't reliable enough at returning the same binding name. When I first adjusted the logic in "addBindingName" (see [the original issue](https://github.com/Azure/azure-functions-nodejs-worker/issues/638)) I thought the problem only repro-ed with multiple workers in parallel, but now I think it can also happen with multiple workers in serial (aka a worker restarts, but the host stays the same). Fwiw, I checked telemetry and only a handful of apps are hitting this issue, but I definitely don't want anyone to hit this at all.

Anyways, my new solution is to create a hash of the binding configuration, which should reliably create the same binding name each time and also be unique within the function (we need name uniqueness at the function level, but not the app level). The only way we could get conflicting names is if they register bindings with the exact same config within a single function, but I have no idea why someone would do that. Regardless, I added an error up front so that it will fail-fast if they're in that situation and be easy for them to fix.

Lastly, I split this PR into two commits for easier review:
- The first moves code to a new file with no functional changes: https://github.com/Azure/azure-functions-nodejs-library/commit/2e24f147ac5a04243c2f5502f48a09aa138da5bf
- The second actually fixes the issue: https://github.com/Azure/azure-functions-nodejs-library/commit/2f08eb60776485200d678a5725667daca5baeb14