### PR TITLE
Update ensureErrorType

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,6 +29,20 @@ export class ReadOnlyError extends AzFuncTypeError {
 
 export function ensureErrorType(err: unknown): Error & Partial<AzFuncError> {
     if (err instanceof Error) {
+        const writable = Object.getOwnPropertyDescriptor(err, 'message')?.writable;
+        if (!writable) {
+            // The motivation for this branch can be found in the below issue:
+            // https://github.com/Azure/azure-functions-nodejs-library/issues/205
+            let readableMessage = err.message;
+            Object.defineProperty(err, 'message', {
+                get() {
+                    return readableMessage;
+                },
+                set(val: string) {
+                    readableMessage = val;
+                },
+            });
+        }
         return err;
     } else {
         let message: string;

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -42,6 +42,25 @@ describe('ensureErrorType', () => {
         expect(ensureErrorType(actualError)).to.equal(actualError);
     });
 
+    it('readonly error', () => {
+        class ReadOnlyError extends Error {
+            get message(): string {
+                return 'a readonly message';
+            }
+        }
+
+        const actualError = new ReadOnlyError();
+
+        // @ts-expect-error: create a function to test that writing throws an exception
+        expect(() => (actualError.message = 'exception')).to.throw();
+
+        const wrappedError = ensureErrorType(actualError);
+        wrappedError.message = 'Readonly error has been modified';
+
+        expect(wrappedError.message).to.equal('Readonly error has been modified');
+        expect(wrappedError.stack).to.contain('Readonly error has been modified');
+    });
+
     function validateError(actual: Error, expectedMessage: string): void {
         expect(actual).to.be.instanceof(Error);
         expect(actual.message).to.equal(expectedMessage);


### PR DESCRIPTION
This is a companion PR to [Check errors are writable #732]( https://github.com/Azure/azure-functions-nodejs-worker/pull/732). 

We have the same code in this Library repo and the Worker repo, so this PR is keeping both in sync as recommended in this comment: https://github.com/Azure/azure-functions-nodejs-worker/pull/732#discussion_r1482242947.

For more details, please see the original PR linked above.