### PR TITLE
Improve error message for streaming on old host version

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,6 +3,7 @@
 
 import { SetupOptions } from '../types';
 import { AzFuncSystemError } from './errors';
+import { tryGetCoreApiLazy } from './utils/tryGetCoreApiLazy';
 import { workerSystemLog } from './utils/workerSystemLog';
 
 let options: SetupOptions = {};
@@ -16,6 +17,16 @@ export function setup(opts: SetupOptions): void {
     if (setupLocked) {
         throw new AzFuncSystemError("Setup options can't be changed after app startup has finished.");
     }
+
+    if (opts.enableHttpStream) {
+        // NOTE: coreApi.log was coincidentally added the same time as http streaming,
+        // so we can use that to validate the host version instead of messing with semver parsing
+        const coreApi = tryGetCoreApiLazy();
+        if (coreApi && !coreApi.log) {
+            throw new AzFuncSystemError(`HTTP streaming requires Azure Functions Host v4.28 or higher.`);
+        }
+    }
+
     options = opts;
     workerSystemLog('information', `Setup options: ${JSON.stringify(options)}`);
 }

--- a/src/utils/workerSystemLog.ts
+++ b/src/utils/workerSystemLog.ts
@@ -8,7 +8,8 @@ import { tryGetCoreApiLazy } from './tryGetCoreApiLazy';
 
 export function workerSystemLog(level: types.LogLevel, ...args: unknown[]): void {
     const coreApi = tryGetCoreApiLazy();
-    if (coreApi) {
+    // NOTE: coreApi.log doesn't exist on older versions of the worker
+    if (coreApi && coreApi.log) {
         coreApi.log(level, 'system', format(...args));
     } else {
         fallbackLogHandler(level, ...args);


### PR DESCRIPTION
Users need v4.28 or higher for stream support. I updated the error message they see if they're on an older version.

Before:

> Worker was unable to load entry point "dist/src/index.js": coreApi.log is not a function

After:

> Worker was unable to load entry point "dist/src/index.js": HTTP streaming requires Azure Functions Host v4.28 or higher.