### PR TITLE
Support params when streaming

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-namespace": "off",
-        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "ignoreRestSiblings": true }],
         "prefer-const": ["error", { "destructuring": "all" }],
         "@typescript-eslint/explicit-member-accessibility": [
             "error",

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -22,7 +22,7 @@ import { toRpcHttp } from './converters/toRpcHttp';
 import { toRpcTypedData } from './converters/toRpcTypedData';
 import { AzFuncSystemError } from './errors';
 import { waitForProxyRequest } from './http/httpProxy';
-import { HttpRequest } from './http/HttpRequest';
+import { createStreamRequest } from './http/HttpRequest';
 import { InvocationContext } from './InvocationContext';
 import { isHttpStreamEnabled } from './setup';
 import { isHttpTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
@@ -78,7 +78,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
                 let input: unknown;
                 if (isHttpTrigger(bindingType) && isHttpStreamEnabled()) {
                     const proxyRequest = await waitForProxyRequest(this.#coreCtx.invocationId);
-                    input = new HttpRequest({ ...binding.data?.http, proxyRequest });
+                    input = createStreamRequest(proxyRequest);
                 } else {
                     input = fromRpcTypedData(binding.data);
                 }

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -78,7 +78,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
                 let input: unknown;
                 if (isHttpTrigger(bindingType) && isHttpStreamEnabled()) {
                     const proxyRequest = await waitForProxyRequest(this.#coreCtx.invocationId);
-                    input = createStreamRequest(proxyRequest);
+                    input = createStreamRequest(proxyRequest, nonNullProp(req, 'triggerMetadata'));
                 } else {
                     input = fromRpcTypedData(binding.data);
                 }


### PR DESCRIPTION
And fix headers to match original user's request. Both of these are made possible because of the trigger metadata property. I tried using query from here as well, but it ended up being the worst of both worlds - it doesn't fix the query array bug (https://github.com/Azure/azure-functions-nodejs-library/issues/168) but it also doesn't match the old non-stream behavior. So I left our current logic which fixes the query array bug.

I did a small refactor in the first commit and second commit is the actual change.

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/229