### PR TITLE
Add support for sql trigger

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
     HttpMethodFunctionOptions,
     ServiceBusQueueFunctionOptions,
     ServiceBusTopicFunctionOptions,
+    SqlFunctionOptions,
     StorageBlobFunctionOptions,
     StorageQueueFunctionOptions,
     TimerFunctionOptions,
@@ -126,6 +127,10 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void {
 
 export function warmup(name: string, options: WarmupFunctionOptions): void {
     generic(name, convertToGenericOptions(options, trigger.warmup));
+}
+
+export function sql(name: string, options: SqlFunctionOptions): void {
+    generic(name, convertToGenericOptions(options, trigger.sql));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,9 @@ export { InvocationContext } from './InvocationContext';
 export * as output from './output';
 export * as trigger from './trigger';
 export { Disposable } from './utils/Disposable';
+
+export enum SqlChangeOperation {
+    Insert = 0,
+    Update = 1,
+    Delete = 2,
+}

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -16,6 +16,8 @@ import {
     ServiceBusQueueTriggerOptions,
     ServiceBusTopicTrigger,
     ServiceBusTopicTriggerOptions,
+    SqlTrigger,
+    SqlTriggerOptions,
     StorageBlobTrigger,
     StorageBlobTriggerOptions,
     StorageQueueTrigger,
@@ -96,6 +98,13 @@ export function warmup(options: WarmupTriggerOptions): WarmupTrigger {
     return addTriggerBindingName({
         ...options,
         type: 'warmupTrigger',
+    });
+}
+
+export function sql(options: SqlTriggerOptions): SqlTrigger {
+    return addTriggerBindingName({
+        ...options,
+        type: 'sqlTrigger',
     });
 }
 

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -8,6 +8,7 @@ import { GenericFunctionOptions } from './generic';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
 import { ServiceBusQueueFunctionOptions, ServiceBusTopicFunctionOptions } from './serviceBus';
 import { SetupOptions } from './setup';
+import { SqlFunctionOptions } from './sql';
 import { StorageBlobFunctionOptions, StorageQueueFunctionOptions } from './storage';
 import { TimerFunctionOptions } from './timer';
 import { WarmupFunctionOptions } from './warmup';
@@ -162,6 +163,13 @@ export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void;
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function warmup(name: string, options: WarmupFunctionOptions): void;
+
+/**
+ * Registers a SQL function in your app that will be triggered when a row is created, updated, or deleted
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function sql(name: string, options: SqlFunctionOptions): void;
 
 /**
  * Registers a generic function in your app that will be triggered based on the type specified in `options.trigger.type`

--- a/types/sql.d.ts
+++ b/types/sql.d.ts
@@ -1,7 +1,40 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FunctionInput, FunctionOutput } from './index';
+import { FunctionInput, FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger } from './index';
+import { InvocationContext } from './InvocationContext';
+
+export type SqlHandler = (changes: SqlChange[], context: InvocationContext) => FunctionResult;
+
+export interface SqlFunctionOptions extends SqlTriggerOptions, Partial<FunctionOptions> {
+    handler: SqlHandler;
+
+    trigger?: SqlTrigger;
+}
+
+export interface SqlTriggerOptions {
+    /**
+     * The name of the table monitored by the trigger.
+     */
+    tableName: string;
+
+    /**
+     * An app setting (or environment variable) with the connection string for the database containing the table monitored for changes
+     */
+    connectionStringSetting: string;
+}
+export type SqlTrigger = FunctionTrigger & SqlTriggerOptions;
+
+export interface SqlChange {
+    Item: unknown;
+    Operation: SqlChangeOperation;
+}
+
+export enum SqlChangeOperation {
+    Insert = 0,
+    Update = 1,
+    Delete = 2,
+}
 
 export interface SqlInputOptions {
     /**

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -13,6 +13,7 @@ import {
     ServiceBusTopicTrigger,
     ServiceBusTopicTriggerOptions,
 } from './serviceBus';
+import { SqlTrigger, SqlTriggerOptions } from './sql';
 import {
     StorageBlobTrigger,
     StorageBlobTriggerOptions,
@@ -71,6 +72,11 @@ export function cosmosDB(options: CosmosDBTriggerOptions): CosmosDBTrigger;
  * [Link to docs and examples](https://learn.microsoft.com/azure/azure-functions/functions-bindings-warmup?tabs=isolated-process&pivots=programming-language-javascript)
  */
 export function warmup(options: WarmupTriggerOptions): WarmupTrigger;
+
+/**
+ * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql-trigger?pivots=programming-language-javascript)
+ */
+export function sql(options: SqlTriggerOptions): SqlTrigger;
 
 /**
  * A generic option that can be used for any trigger type


### PR DESCRIPTION
We already have sql input/output bindings and I was just waiting for the sql trigger to GA before I added it (which happened somewhat recently). SQL trigger docs [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql-trigger?tabs=isolated-process%2Cportal&pivots=programming-language-javascript)

See example code in the e2e test PR here: https://github.com/Azure/azure-functions-nodejs-e2e-tests/pull/36

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/88