### PR TITLE
Add ability to specify capabilities in setup

### DIFF
--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -24,7 +24,7 @@ import { AzFuncSystemError } from './errors';
 import { waitForProxyRequest } from './http/httpProxy';
 import { createStreamRequest } from './http/HttpRequest';
 import { InvocationContext } from './InvocationContext';
-import { isHttpStreamEnabled } from './setup';
+import { enableHttpStream } from './setup';
 import { isHttpTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
 import { isDefined, nonNullProp, nonNullValue } from './utils/nonNull';
 
@@ -76,7 +76,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
                 const bindingType = rpcBinding.type;
 
                 let input: unknown;
-                if (isHttpTrigger(bindingType) && isHttpStreamEnabled()) {
+                if (isHttpTrigger(bindingType) && enableHttpStream) {
                     const proxyRequest = await waitForProxyRequest(this.#coreCtx.invocationId);
                     input = createStreamRequest(proxyRequest, nonNullProp(req, 'triggerMetadata'));
                 } else {

--- a/src/ProgrammingModel.ts
+++ b/src/ProgrammingModel.ts
@@ -16,16 +16,16 @@ export class ProgrammingModel implements coreTypes.ProgrammingModel {
         return new InvocationModel(coreCtx);
     }
 
-    async getCapabilities(capabilities: WorkerCapabilities): Promise<WorkerCapabilities> {
+    async getCapabilities(workerCapabilities: WorkerCapabilities): Promise<WorkerCapabilities> {
         lockSetup();
 
         if (enableHttpStream) {
             const httpUri = await setupHttpProxy();
-            capabilities.HttpUri = httpUri;
+            workerCapabilities.HttpUri = httpUri;
         }
 
-        Object.assign(capabilities, libraryCapabilities);
+        Object.assign(workerCapabilities, libraryCapabilities);
 
-        return capabilities;
+        return workerCapabilities;
     }
 }

--- a/src/ProgrammingModel.ts
+++ b/src/ProgrammingModel.ts
@@ -6,7 +6,7 @@ import { CoreInvocationContext, WorkerCapabilities } from '@azure/functions-core
 import { version } from './constants';
 import { setupHttpProxy } from './http/httpProxy';
 import { InvocationModel } from './InvocationModel';
-import { isHttpStreamEnabled, lockSetup } from './setup';
+import { capabilities as libraryCapabilities, enableHttpStream, lockSetup } from './setup';
 
 export class ProgrammingModel implements coreTypes.ProgrammingModel {
     name = '@azure/functions';
@@ -19,10 +19,12 @@ export class ProgrammingModel implements coreTypes.ProgrammingModel {
     async getCapabilities(capabilities: WorkerCapabilities): Promise<WorkerCapabilities> {
         lockSetup();
 
-        if (isHttpStreamEnabled()) {
+        if (enableHttpStream) {
             const httpUri = await setupHttpProxy();
             capabilities.HttpUri = httpUri;
         }
+
+        Object.assign(capabilities, libraryCapabilities);
 
         return capabilities;
     }

--- a/src/converters/toRpcHttp.ts
+++ b/src/converters/toRpcHttp.ts
@@ -5,7 +5,7 @@ import { RpcHttpData, RpcTypedData } from '@azure/functions-core';
 import { AzFuncSystemError } from '../errors';
 import { sendProxyResponse } from '../http/httpProxy';
 import { HttpResponse } from '../http/HttpResponse';
-import { isHttpStreamEnabled } from '../setup';
+import { enableHttpStream } from '../setup';
 import { toRpcHttpCookie } from './toRpcHttpCookie';
 import { toRpcTypedData } from './toRpcTypedData';
 
@@ -19,7 +19,7 @@ export async function toRpcHttp(invocationId: string, data: unknown): Promise<Rp
     }
 
     const response = data instanceof HttpResponse ? data : new HttpResponse(data);
-    if (isHttpStreamEnabled()) {
+    if (enableHttpStream) {
         // send http data over http proxy instead of rpc
         await sendProxyResponse(invocationId, response);
         return;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,15 +3,17 @@
 
 import { SetupOptions } from '../types';
 import { AzFuncSystemError } from './errors';
+import { isDefined } from './utils/nonNull';
 import { tryGetCoreApiLazy } from './utils/tryGetCoreApiLazy';
 import { workerSystemLog } from './utils/workerSystemLog';
 
-let options: SetupOptions = {};
 let setupLocked = false;
-
 export function lockSetup(): void {
     setupLocked = true;
 }
+
+export let enableHttpStream = false;
+export const capabilities: Record<string, string> = {};
 
 export function setup(opts: SetupOptions): void {
     if (setupLocked) {
@@ -27,10 +29,21 @@ export function setup(opts: SetupOptions): void {
         }
     }
 
-    options = opts;
-    workerSystemLog('information', `Setup options: ${JSON.stringify(options)}`);
-}
+    if (isDefined(opts.enableHttpStream)) {
+        enableHttpStream = opts.enableHttpStream;
+    }
 
-export function isHttpStreamEnabled(): boolean {
-    return !!options.enableHttpStream;
+    if (opts.capabilities) {
+        for (let [key, val] of Object.entries(opts.capabilities)) {
+            if (isDefined(val)) {
+                val = String(val);
+                workerSystemLog('debug', `Capability ${key} set to ${val}.`);
+                capabilities[key] = val;
+            }
+        }
+    }
+
+    if (enableHttpStream) {
+        workerSystemLog('debug', `HTTP streaming enabled.`);
+    }
 }

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -20,7 +20,7 @@ describe('setup', () => {
         setup({ capabilities: {} });
         expect(enableHttpStream).to.equal(true);
 
-        // set to true
+        // set to false
         setup({ enableHttpStream: false });
         expect(enableHttpStream).to.equal(false);
     });

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { capabilities, enableHttpStream, setup } from '../src/setup';
+
+describe('setup', () => {
+    it('enableHttpStream', () => {
+        // default
+        expect(enableHttpStream).to.equal(false);
+
+        // set to true
+        setup({ enableHttpStream: true });
+        expect(enableHttpStream).to.equal(true);
+
+        // don't change if not explicitly set
+        setup({});
+        expect(enableHttpStream).to.equal(true);
+        setup({ capabilities: {} });
+        expect(enableHttpStream).to.equal(true);
+
+        // set to true
+        setup({ enableHttpStream: false });
+        expect(enableHttpStream).to.equal(false);
+    });
+
+    it('capabilities', () => {
+        // default
+        expect(capabilities).to.deep.equal({});
+
+        // various setting & merging without replacing
+        setup({ capabilities: { a: '1' } });
+        expect(capabilities).to.deep.equal({ a: '1' });
+        setup({});
+        expect(capabilities).to.deep.equal({ a: '1' });
+        setup({ capabilities: { b: '2' } });
+        expect(capabilities).to.deep.equal({ a: '1', b: '2' });
+        setup({ capabilities: { a: '3' } });
+        expect(capabilities).to.deep.equal({ a: '3', b: '2' });
+
+        // boolean converted to string
+        setup({ capabilities: { c: true } });
+        expect(capabilities).to.deep.equal({ a: '3', b: '2', c: 'true' });
+    });
+});

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -15,7 +15,8 @@ import { WarmupFunctionOptions } from './warmup';
 
 /**
  * Optional method to configure the behavior of your app.
- * This can only be done during app startup, before invocations occur
+ * This can only be done during app startup, before invocations occur.
+ * If called multiple times, options will be merged with the previous options specified.
  */
 export declare function setup(options: SetupOptions): void;
 

--- a/types/setup.d.ts
+++ b/types/setup.d.ts
@@ -3,8 +3,14 @@
 
 export interface SetupOptions {
     /**
-     * PREVIEW: Stream http requests and responses instead of loading entire body in memory.
+     * Stream http requests and responses instead of loading entire body in memory.
      * [Learn more here](https://aka.ms/AzFuncNodeHttpStreams)
      */
     enableHttpStream?: boolean;
+
+    /**
+     * Dictionary of Node.js worker capabilities.
+     * This will be merged with existing capabilities specified by the Node.js worker and library.
+     */
+    capabilities?: Record<string, string | boolean>;
 }


### PR DESCRIPTION
and clarify that setup options are merged instead of replaced. Otherwise there would be no way for multiple places (i.e. the user's app and an otel package) to adjust setup config.

Related to otel work https://github.com/Azure/azure-functions-nodejs-library/issues/245, we will need to do something like this:
```typescript
app.setup({
    capabilities: {
        WorkerOpenTelemetryEnabled: true,
    },
});
```