### PR TITLE
Export LogHookContext class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { AppStartContext } from './hooks/AppStartContext';
 export { AppTerminateContext } from './hooks/AppTerminateContext';
 export { HookContext } from './hooks/HookContext';
 export { InvocationHookContext } from './hooks/InvocationHookContext';
+export { LogHookContext } from './hooks/LogHookContext';
 export { PostInvocationContext } from './hooks/PostInvocationContext';
 export { PreInvocationContext } from './hooks/PreInvocationContext';
 export { HttpRequest } from './http/HttpRequest';


### PR DESCRIPTION
Missed this during https://github.com/Azure/azure-functions-nodejs-library/pull/253. This would only affect folks who need to create the class as a part of their unit tests