### PR TITLE
Update release pipeline to use 1es templates [v3.x]

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,47 +1,65 @@
 parameters:
-- name: NpmPublishTag
-  displayName: 'Tag'
-  type: string
-  default: 'legacy'
-- name: NpmPublishDryRun
-  displayName: 'Dry Run'
-  type: boolean
-  default: true
+    - name: NpmPublishTag
+      displayName: 'Tag'
+      type: string
+      default: 'legacy'
+    - name: NpmPublishDryRun
+      displayName: 'Dry Run'
+      type: boolean
+      default: true
 
 trigger: none
 pr: none
 
 resources:
-  pipelines:
-  - pipeline: nodeLibraryCI
-    project: 'Azure Functions'
-    source: azure-functions-nodejs-library.build
-    branch: v3.x
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+    pipelines:
+        - pipeline: officialBuild
+          project: internal
+          source: nodejs-library.official
+          branch: v3.x
 
-jobs:
-- job: Release
-  pool:
-    name: '1ES-Hosted-AzFunc'
-    demands:
-    - ImageOverride -equals MMSUbuntu20.04TLS
-  steps:
-  - download: nodeLibraryCI
-  - task: NodeTool@0
-    displayName: 'Install Node.js'
-    inputs:
-      versionSpec: 14.x
-  - script: npm ci
-    displayName: 'npm ci'
-  - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "$(Pipeline.Workspace)/nodeLibraryCI/drop"'
-    displayName: 'validate release'
-  - script: mv *.tgz package.tgz
-    displayName: 'Rename tgz file' # because the publish command below requires an exact path
-    workingDirectory: '$(Pipeline.Workspace)/nodeLibraryCI/drop'
-  - task: Npm@1
-    displayName: 'npm publish'
-    inputs:
-      command: custom
-      workingDir: '$(Pipeline.Workspace)/nodeLibraryCI/drop'
-      verbose: true
-      customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}'
-      customEndpoint: 'Functions Node.js Library Publish'
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        sdl:
+            sourceAnalysisPool:
+                name: 1es-pool-azfunc
+                image: 1es-windows-2022
+                os: windows
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
+
+        stages:
+            - stage: Release
+              pool:
+                  name: 1es-pool-azfunc
+                  image: 1es-ubuntu-22.04
+                  os: linux
+              jobs:
+                  - job: Release
+                    steps:
+                        - download: officialBuild
+                        - task: NodeTool@0
+                          displayName: 'Install Node.js'
+                          inputs:
+                              versionSpec: 14.x
+                        - script: npm ci
+                          displayName: 'npm ci'
+                        - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "$(Pipeline.Workspace)/officialBuild/drop"'
+                          displayName: 'validate release'
+                        - script: mv *.tgz package.tgz
+                          displayName: 'Rename tgz file' # because the publish command below requires an exact path
+                          workingDirectory: '$(Pipeline.Workspace)/officialBuild/drop'
+                        - task: Npm@1
+                          displayName: 'npm publish'
+                          inputs:
+                              command: custom
+                              workingDir: '$(Pipeline.Workspace)/officialBuild/drop'
+                              verbose: true
+                              customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}'
+                              customEndpoint: nodejs-library-npm

--- a/scripts/validateRelease.ts
+++ b/scripts/validateRelease.ts
@@ -17,7 +17,7 @@ npm run validateRelease -- --publishTag preview --dropPath /example/path/`);
 }
 
 function validateRelease(publishTag: string, dropPath: string): void {
-    const files = readdirSync(dropPath);
+    const files = readdirSync(dropPath).filter((f) => f.endsWith('.tgz'));
     if (files.length !== 1) {
         throw new Error('Drop path should have one tgz file');
     }


### PR DESCRIPTION
Same as https://github.com/Azure/azure-functions-nodejs-library/pull/270 but for v3.x branch