### PR TITLE
Fix undefined params when http streaming is on

### DIFF
--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -153,9 +153,8 @@ export function createStreamRequest(
 
     const params: Record<string, string> = {};
     for (const [key, rpcValue] of Object.entries(rpcParams)) {
-        const value = fromRpcTypedData(rpcValue);
-        if (typeof value === 'string') {
-            params[key] = value;
+        if (isDefined(rpcValue.string)) {
+            params[key] = rpcValue.string;
         }
     }
 


### PR DESCRIPTION
When the http stream feature is turned on, some params are not being set. This is because `fromRpcTypedData` tries to JSON parse strings and will return values that are objects/numbers/etc which we don't want. Fix was to bypass `fromRpcTypedData` and return the string directly.

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/285