### PR TITLE
Bump 'cookie' version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.5.1",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.6.0",
+                "cookie": "^0.7.2",
                 "long": "^4.0.0",
                 "undici": "^5.13.0"
             },
@@ -1417,9 +1417,10 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -6672,9 +6673,9 @@
             "dev": true
         },
         "cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
         "cosmiconfig": {
             "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "watch": "webpack --watch --mode development"
     },
     "dependencies": {
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.2",
         "long": "^4.0.0",
         "undici": "^5.13.0"
     },


### PR DESCRIPTION
Fixes #301 
bump cookie version to a non-vulnerable version
ref: https://github.com/advisories/GHSA-pxg6-pf52-xh8x