### PR TITLE
Add port validation checks for HTTP streaming

### DIFF
--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -17,16 +17,13 @@ const invocRequestEmitter = new EventEmitter();
 
 export async function waitForProxyRequest(invocationId: string): Promise<http.IncomingMessage> {
     return new Promise((resolve, _reject) => {
-        workerSystemLog('debug', 'Waiting for proxy request', { invocationId });
         const req = requests[invocationId];
         if (req) {
             resolve(req);
-            workerSystemLog('debug', 'Proxy request found', { invocationId });
             delete requests[invocationId];
         } else {
             invocRequestEmitter.once(invocationId, () => {
                 const req = requests[invocationId];
-                workerSystemLog('debug', 'Proxy request else statement');
                 if (req) {
                     resolve(req);
                     delete requests[invocationId];
@@ -38,13 +35,11 @@ export async function waitForProxyRequest(invocationId: string): Promise<http.In
 
 const invocationIdHeader = 'x-ms-invocation-id';
 export async function sendProxyResponse(invocationId: string, userRes: HttpResponse): Promise<void> {
-    workerSystemLog('debug', 'Sending proxy response', { invocationId });
     const proxyRes = nonNullProp(responses, invocationId);
     delete responses[invocationId];
     for (const [key, val] of userRes.headers.entries()) {
         proxyRes.setHeader(key, val);
     }
-    workerSystemLog('debug', 'Http proxy headers set');
     proxyRes.setHeader(invocationIdHeader, invocationId);
     proxyRes.statusCode = userRes.status;
 
@@ -54,9 +49,7 @@ export async function sendProxyResponse(invocationId: string, userRes: HttpRespo
 
     if (userRes.body) {
         for await (const chunk of userRes.body.values()) {
-            workerSystemLog('debug', 'Writing proxy response chunk');
             proxyRes.write(chunk);
-            workerSystemLog('debug', 'Http proxy response chunks written');
         }
     }
     proxyRes.end();
@@ -94,12 +87,10 @@ function setCookies(userRes: HttpResponse, proxyRes: http.ServerResponse): void 
 export async function setupHttpProxy(): Promise<string> {
     return new Promise((resolve, reject) => {
         const server = http.createServer();
-        workerSystemLog('debug', 'Http proxy server created');
 
         server.on('request', (req, res) => {
             const invocationId = req.headers[invocationIdHeader];
             if (typeof invocationId === 'string') {
-                workerSystemLog('debug', 'Http proxy request received', { invocationId });
                 requests[invocationId] = req;
                 responses[invocationId] = res;
                 invocRequestEmitter.emit(invocationId);

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -13,7 +13,7 @@ import { HttpResponse } from './HttpResponse';
 const requests: Record<string, http.IncomingMessage> = {};
 const responses: Record<string, http.ServerResponse> = {};
 const minPort = 55000;
-const maxPort = 65535;
+const maxPort = 55025;
 
 const invocRequestEmitter = new EventEmitter();
 
@@ -137,20 +137,21 @@ export async function setupHttpProxy(): Promise<string> {
     });
 }
 
-// Function to get a random port within a specified range
-function getRandomPort(): number {
-    return Math.floor(Math.random() * (maxPort - minPort + 1)) + minPort;
-}
-
 // Function to find an open port starting from a specified port
 function findOpenPort(callback: (port: number) => void): void {
     const server = net.createServer();
 
     function tryPort(port: number) {
+        if (port > maxPort) {
+            // If we've reached the maximum port, throw an error
+            throw new AzFuncSystemError(
+                `No available ports found between ${minPort} and ${maxPort}. To enable HTTP streaming, please open a port in this range.`
+            );
+        }
+
         server.once('error', () => {
-            // If the port is unavailable, get a random port and try again
-            const randomPort = getRandomPort();
-            tryPort(randomPort);
+            // If the port is unavailable, increment and try the next one
+            tryPort(port + 1);
         });
 
         // If the port is available, return it

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -135,14 +135,20 @@ export async function setupHttpProxy(): Promise<string> {
     });
 }
 
+// Function to get a random port within a specified range
+function getRandomPort(minPort = 55000, maxPort = 65535): number {
+    return Math.floor(Math.random() * (maxPort - minPort + 1)) + minPort;
+}
+
 // Function to find an open port starting from a specified port
 function findOpenPort(startingPort: number, callback: (port: number) => void): void {
     const server = net.createServer();
 
     function tryPort(port: number) {
         server.once('error', () => {
-            // If the port is unavailable, increment and try the next one
-            tryPort(port + 1);
+            // If the port is unavailable, get a random port and try again
+            const randomPort = getRandomPort();
+            tryPort(randomPort);
         });
 
         // If the port is available, return it

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -12,6 +12,8 @@ import { HttpResponse } from './HttpResponse';
 
 const requests: Record<string, http.IncomingMessage> = {};
 const responses: Record<string, http.ServerResponse> = {};
+const minPort = 55000;
+const maxPort = 65535;
 
 const invocRequestEmitter = new EventEmitter();
 
@@ -111,7 +113,7 @@ export async function setupHttpProxy(): Promise<string> {
                 if (address.port === 0) {
                     // Auto-assigned port is 0, find and bind to an open port
                     workerSystemLog('debug', `Port 0 assigned. Finding open port.`);
-                    findOpenPort(51929, (openPort: number) => {
+                    findOpenPort((openPort: number) => {
                         // Close the server and re-listen on the found open port
                         server.close();
                         server.listen(openPort, () => {
@@ -136,12 +138,12 @@ export async function setupHttpProxy(): Promise<string> {
 }
 
 // Function to get a random port within a specified range
-function getRandomPort(minPort = 55000, maxPort = 65535): number {
+function getRandomPort(): number {
     return Math.floor(Math.random() * (maxPort - minPort + 1)) + minPort;
 }
 
 // Function to find an open port starting from a specified port
-function findOpenPort(startingPort: number, callback: (port: number) => void): void {
+function findOpenPort(callback: (port: number) => void): void {
     const server = net.createServer();
 
     function tryPort(port: number) {
@@ -166,5 +168,5 @@ function findOpenPort(startingPort: number, callback: (port: number) => void): v
     }
 
     // Start trying from the specified starting port
-    tryPort(startingPort);
+    tryPort(minPort);
 }

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -115,22 +115,24 @@ export async function setupHttpProxy(): Promise<string> {
 
         server.listen(() => {
             const address = server.address();
-            if (address !== null && address.port === 0) {
-                // Auto-assigned port is 0, find and bind to an open port
-                workerSystemLog('debug', `VICTORIA: Port 0 assigned. Finding open port.`);
-                findOpenPort(51929, (openPort) => {
-                    workerSystemLog('debug', `VICTORIA: found open port: ${openPort}`);
-                    // Close the server and re-listen on the found open port
-                    server.close();
-                    server.listen(openPort, () => {
-                        workerSystemLog('debug', `VICTORIA: server is now listening on found open port: ${openPort}`);
+            // Valid address has been created
+            if (address !== null && typeof address === 'object') {
+                if (address.port === 0) {
+                    // Auto-assigned port is 0, find and bind to an open port
+                    workerSystemLog('debug', `Port 0 assigned. Finding open port.`);
+                    findOpenPort(51929, (openPort: number) => {
+                        // Close the server and re-listen on the found open port
+                        server.close();
+                        server.listen(openPort, () => {
+                            workerSystemLog('debug', `Server is now listening on found open port: ${openPort}`);
+                        });
+                        resolve(`http://localhost:${openPort}/`);
                     });
-                    resolve(`http://localhost:${openPort}/`);
-                });
-            } else if (address !== null && typeof address === 'object') {
-                // Auto-assigned port is not 0
-                workerSystemLog('debug', `VICTORIA: auto-assigned port is valid. Port: ${address.port}`);
-                resolve(`http://localhost:${address.port}/`);
+                } else {
+                    // Auto-assigned port is not 0
+                    workerSystemLog('debug', `Auto-assigned port is valid. Port: ${address.port}`);
+                    resolve(`http://localhost:${address.port}/`);
+                }
             } else {
                 reject(new AzFuncSystemError('Unexpected server address during http proxy setup'));
             }
@@ -143,10 +145,10 @@ export async function setupHttpProxy(): Promise<string> {
 }
 
 // Function to find an open port starting from a specified port
-function findOpenPort(startingPort, callback) {
+function findOpenPort(startingPort: number, callback: (port: number) => void): void {
     const server = net.createServer();
 
-    function tryPort(port) {
+    function tryPort(port: number) {
         server.once('error', () => {
             // If the port is unavailable, increment and try the next one
             tryPort(port + 1);
@@ -154,9 +156,12 @@ function findOpenPort(startingPort, callback) {
 
         // If the port is available, return it
         server.once('listening', () => {
-            const port = server.address().port;
-            server.close();
-            callback(port);
+            const address = server.address();
+            if (address !== null && typeof address === 'object') {
+                port = address.port;
+                server.close();
+                callback(port);
+            }
         });
 
         // Try binding to the given port

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -4,6 +4,7 @@
 import { serialize as serializeCookie } from 'cookie';
 import { EventEmitter } from 'events';
 import * as http from 'http';
+import * as net from 'net';
 import { AzFuncSystemError, ensureErrorType } from '../errors';
 import { nonNullProp } from '../utils/nonNull';
 import { workerSystemLog } from '../utils/workerSystemLog';
@@ -16,13 +17,16 @@ const invocRequestEmitter = new EventEmitter();
 
 export async function waitForProxyRequest(invocationId: string): Promise<http.IncomingMessage> {
     return new Promise((resolve, _reject) => {
+        workerSystemLog('debug', 'Waiting for proxy request', { invocationId });
         const req = requests[invocationId];
         if (req) {
             resolve(req);
+            workerSystemLog('debug', 'Proxy request found', { invocationId });
             delete requests[invocationId];
         } else {
             invocRequestEmitter.once(invocationId, () => {
                 const req = requests[invocationId];
+                workerSystemLog('debug', 'Proxy request else statement');
                 if (req) {
                     resolve(req);
                     delete requests[invocationId];
@@ -34,11 +38,13 @@ export async function waitForProxyRequest(invocationId: string): Promise<http.In
 
 const invocationIdHeader = 'x-ms-invocation-id';
 export async function sendProxyResponse(invocationId: string, userRes: HttpResponse): Promise<void> {
+    workerSystemLog('debug', 'Sending proxy response', { invocationId });
     const proxyRes = nonNullProp(responses, invocationId);
     delete responses[invocationId];
     for (const [key, val] of userRes.headers.entries()) {
         proxyRes.setHeader(key, val);
     }
+    workerSystemLog('debug', 'Http proxy headers set');
     proxyRes.setHeader(invocationIdHeader, invocationId);
     proxyRes.statusCode = userRes.status;
 
@@ -48,7 +54,9 @@ export async function sendProxyResponse(invocationId: string, userRes: HttpRespo
 
     if (userRes.body) {
         for await (const chunk of userRes.body.values()) {
+            workerSystemLog('debug', 'Writing proxy response chunk');
             proxyRes.write(chunk);
+            workerSystemLog('debug', 'Http proxy response chunks written');
         }
     }
     proxyRes.end();
@@ -86,10 +94,12 @@ function setCookies(userRes: HttpResponse, proxyRes: http.ServerResponse): void 
 export async function setupHttpProxy(): Promise<string> {
     return new Promise((resolve, reject) => {
         const server = http.createServer();
+        workerSystemLog('debug', 'Http proxy server created');
 
         server.on('request', (req, res) => {
             const invocationId = req.headers[invocationIdHeader];
             if (typeof invocationId === 'string') {
+                workerSystemLog('debug', 'Http proxy request received', { invocationId });
                 requests[invocationId] = req;
                 responses[invocationId] = res;
                 invocRequestEmitter.emit(invocationId);
@@ -103,12 +113,22 @@ export async function setupHttpProxy(): Promise<string> {
             workerSystemLog('error', `Http proxy error: ${err.stack || err.message}`);
         });
 
-        server.listen(() => {
-            const address = server.address();
-            if (address !== null && typeof address === 'object') {
-                resolve(`http://localhost:${address.port}/`);
+        server.listen(0, () => {
+            workerSystemLog('debug', `VICTORIA: auto-assigned port: ${server.address().port}`);
+
+            // If port is still 0, find and bind to an open port
+            if (server.address().port === 0) {
+                workerSystemLog('debug', `VICTORIA: Port 0 assigned. Finding open port.`);
+                findOpenPort(51929, (openPort) => {
+                    workerSystemLog('debug', `VICTORIA: found open port: ${openPort}`);
+                    server.close();  // Close the server
+                    server.listen(openPort, () => {
+                        workerSystemLog('debug', `VICTORIA: server is now listening on found open port: ${openPort}`);
+                    });
+                    resolve(`http://localhost:${openPort}/`);
+                });
             } else {
-                reject(new AzFuncSystemError('Unexpected server address during http proxy setup'));
+                resolve(`http://localhost:${server.address().port}/`);
             }
         });
 
@@ -117,3 +137,28 @@ export async function setupHttpProxy(): Promise<string> {
         });
     });
 }
+
+
+// Function to find an open port starting from a specified port
+function findOpenPort(startingPort, callback) {
+    const server = net.createServer();
+
+    function tryPort(port) {
+      server.once('error', () => {
+        // If the port is unavailable, increment and try the next one
+        tryPort(port + 1);
+      });
+
+      server.once('listening', () => {
+        const port = server.address().port;
+        server.close();
+        callback(port);
+      });
+
+      // Try binding to the given port
+      server.listen(port);
+    }
+
+    // Start trying from the specified starting port
+    tryPort(startingPort);
+  }

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -113,22 +113,26 @@ export async function setupHttpProxy(): Promise<string> {
             workerSystemLog('error', `Http proxy error: ${err.stack || err.message}`);
         });
 
-        server.listen(0, () => {
-            workerSystemLog('debug', `VICTORIA: auto-assigned port: ${server.address().port}`);
-
-            // If port is still 0, find and bind to an open port
-            if (server.address().port === 0) {
+        server.listen(() => {
+            const address = server.address();
+            if (address !== null && address.port === 0) {
+                // Auto-assigned port is 0, find and bind to an open port
                 workerSystemLog('debug', `VICTORIA: Port 0 assigned. Finding open port.`);
                 findOpenPort(51929, (openPort) => {
                     workerSystemLog('debug', `VICTORIA: found open port: ${openPort}`);
-                    server.close();  // Close the server
+                    // Close the server and re-listen on the found open port
+                    server.close();
                     server.listen(openPort, () => {
                         workerSystemLog('debug', `VICTORIA: server is now listening on found open port: ${openPort}`);
                     });
                     resolve(`http://localhost:${openPort}/`);
                 });
+            } else if (address !== null && typeof address === 'object') {
+                // Auto-assigned port is not 0
+                workerSystemLog('debug', `VICTORIA: auto-assigned port is valid. Port: ${address.port}`);
+                resolve(`http://localhost:${address.port}/`);
             } else {
-                resolve(`http://localhost:${server.address().port}/`);
+                reject(new AzFuncSystemError('Unexpected server address during http proxy setup'));
             }
         });
 
@@ -138,27 +142,27 @@ export async function setupHttpProxy(): Promise<string> {
     });
 }
 
-
 // Function to find an open port starting from a specified port
 function findOpenPort(startingPort, callback) {
     const server = net.createServer();
 
     function tryPort(port) {
-      server.once('error', () => {
-        // If the port is unavailable, increment and try the next one
-        tryPort(port + 1);
-      });
+        server.once('error', () => {
+            // If the port is unavailable, increment and try the next one
+            tryPort(port + 1);
+        });
 
-      server.once('listening', () => {
-        const port = server.address().port;
-        server.close();
-        callback(port);
-      });
+        // If the port is available, return it
+        server.once('listening', () => {
+            const port = server.address().port;
+            server.close();
+            callback(port);
+        });
 
-      // Try binding to the given port
-      server.listen(port);
+        // Try binding to the given port
+        server.listen(port);
     }
 
     // Start trying from the specified starting port
     tryPort(startingPort);
-  }
+}


### PR DESCRIPTION
For HTTP streaming, the port is selected by the platform. However, there was no logic that checks if the selected port is valid and available. In the case where the OS is Windows and VNET integration is enabled, the platform defaults to port 0. Port 0 isn't valid, so any proxy requests fail, and the function execution times out.

This fix adds validation on the selected port value. If the port value is 0, the worker will search for and bind to an available port. It first starts searching at port 55000, and if that port isn't available, it will pick a random port between 55000 and 55025 (max port value) and search again. It continues this process until a port is found or throws an error if none are found.

There are no behavioral changes if the selected port value is not 0. The only scenario this change affects then is for Windows + VNET integration enabled.