### PR TITLE
allow null in jsonBody

### DIFF
--- a/src/http/HttpResponse.ts
+++ b/src/http/HttpResponse.ts
@@ -27,7 +27,7 @@ export class HttpResponse implements types.HttpResponse {
             this.#uRes = init.undiciResponse;
         } else {
             const uResInit: uResponseInit = { status: init.status, headers: init.headers };
-            if (isDefined(init.jsonBody)) {
+            if (init.jsonBody !== undefined) {
                 this.#uRes = uResponse.json(init.jsonBody, uResInit);
             } else {
                 this.#uRes = new uResponse(init.body, uResInit);


### PR DESCRIPTION
with this change a `{ jsonBody: null }` will be serialized as JSON, in pair with how JSON.stringfy works
https://github.com/Azure/azure-functions-nodejs-library/issues/325