### PR TITLE
Revert "Updating the undici Major Version (#350)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@azure/functions",
-    "version": "4.7.3",
+    "version": "4.7.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.7.3",
+            "version": "4.7.4",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^0.7.0",
                 "long": "^4.0.0",
-                "undici": "^7.10.0"
+                "undici": "^5.29.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -237,6 +237,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -6439,12 +6448,15 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
-            "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
             "engines": {
-                "node": ">=20.18.1"
+                "node": ">=14.0"
             }
         },
         "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.7.3",
+    "version": "4.7.4",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",
@@ -43,7 +43,7 @@
     "dependencies": {
         "cookie": "^0.7.0",
         "long": "^4.0.0",
-        "undici": "^7.10.0"
+        "undici": "^5.29.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.7.3';
+export const version = '4.7.4';
 
 export const returnBindingKey = '$return';

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -96,7 +96,6 @@ export class HttpRequest implements types.HttpRequest {
     }
 
     async formData(): Promise<FormData> {
-        // eslint-disable-next-line deprecation/deprecation
         return this.#uReq.formData();
     }
 

--- a/src/http/HttpResponse.ts
+++ b/src/http/HttpResponse.ts
@@ -63,7 +63,6 @@ export class HttpResponse implements types.HttpResponse {
     }
 
     async formData(): Promise<FormData> {
-        // eslint-disable-next-line deprecation/deprecation
         return this.#uRes.formData();
     }
 

--- a/test/http/HttpRequest.test.ts
+++ b/test/http/HttpRequest.test.ts
@@ -5,6 +5,7 @@ import 'mocha';
 import * as chai from 'chai';
 import { expect } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { File } from 'undici';
 import { HttpRequest } from '../../src/http/HttpRequest';
 
 chai.use(chaiAsPromised);
@@ -134,7 +135,7 @@ value2
             const contentTypes = ['application/octet-stream', 'application/json', 'text/plain', 'invalid'];
             for (const contentType of contentTypes) {
                 const req = createFormRequest('', contentType);
-                await expect(req.formData()).to.eventually.be.rejectedWith(/Content-Type was not one of /i);
+                await expect(req.formData()).to.eventually.be.rejectedWith(/Could not parse content as FormData/i);
             }
         });
     });


### PR DESCRIPTION
This reverts commit c543818f34ebc9f939c08d96d94aa9204ece1618.

The support range for undici in newer versions does not match the current @azure/functions support range.

The original commit broke Node.js 18 support, due to unidici 7 only supporting Node.js 20 and above. Latest undici 6 supports >=18.17, while the latest undici release that had full Node.js 18 support is v6.13.0. Since v6.13.0 has known security issues, it's just a plain revert.

Ref: #350