### PR TITLE
Fixing the type error in the library for customers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.7.2-preview",
+    "version": "4.7.3-preview",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.7.2-preview';
+export const version = '4.7.3-preview';
 
 export const returnBindingKey = '$return';

--- a/types/serviceBus.d.ts
+++ b/types/serviceBus.d.ts
@@ -4,7 +4,7 @@
 import { FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';
 
-export type ServiceBusQueueHandler = (messages: unknown, context: InvocationContext) => FunctionResult;
+export type ServiceBusQueueHandler = (messages: unknown | any, context: InvocationContext) => FunctionResult;
 
 export interface ServiceBusQueueFunctionOptions extends ServiceBusQueueTriggerOptions, Partial<FunctionOptions> {
     handler: ServiceBusQueueHandler;


### PR DESCRIPTION
Description

This PR provides a very quick fix related to types for the Service Bus handler.

Issue

The IDE highlights that the type ServiceBusMessageContext is not supported in the definition. This change addresses the type error so that consumers of the library do not encounter IDE warnings or errors when using Service Bus handler types.