### PR TITLE
McpTool isn't imported with type-only imports and fails for builds with verbatimModuleSyntax enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.8.1",
+    "version": "4.8.2",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.8.1';
+export const version = '4.8.2';
 
 export const returnBindingKey = '$return';

--- a/src/utils/toolProperties.ts
+++ b/src/utils/toolProperties.ts
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Args, McpToolProperty } from '../../types/mcpTool';
+import type { Args } from '../../types/mcpTool';
+import { McpToolProperty } from '../../types/mcpTool';
 
 /**
  * Fluent API builder for creating MCP Tool properties

--- a/test/converters/toMcpToolTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpToolTriggerOptionsToRpc.test.ts
@@ -5,7 +5,8 @@ import 'mocha';
 import { expect } from 'chai';
 import { converToMcpToolTriggerOptionsToRpc } from '../../src/converters/toMcpToolTriggerOptionsToRpc';
 import { arg } from '../../src/utils/toolProperties';
-import { Args, McpToolProperty, McpToolTriggerOptions } from '../../types/mcpTool';
+import type { Args } from '../../types/mcpTool';
+import { McpToolProperty, McpToolTriggerOptions } from '../../types/mcpTool';
 
 describe('converToMcpToolTriggerOptionsToRpc', () => {
     describe('basic conversion', () => {


### PR DESCRIPTION
Error: 'Args' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled

Root Cause: The [Args] interface was being imported as a regular import instead of a type-only import.


Below is the related issue

https://github.com/Azure/azure-functions-nodejs-library/issues/380