### PR TITLE
Remove Undici Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.10.0",
+    "version": "4.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.10.0",
+            "version": "4.11.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",
                 "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "long": "^4.0.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -273,15 +272,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -6568,18 +6558,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
             }
         },
         "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.10.0",
+    "version": "4.11.0",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "dependencies": {
         "@azure/functions-extensions-base": "0.2.0",
         "cookie": "^0.7.0",
-        "long": "^4.0.0",
-        "undici": "^5.29.0"
+        "long": "^4.0.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.10.0';
+export const version = '4.11.0';
 
 export const returnBindingKey = '$return';

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -8,7 +8,6 @@ import { Blob } from 'buffer';
 import { IncomingMessage } from 'http';
 import * as stream from 'stream';
 import { ReadableStream } from 'stream/web';
-import { FormData, Headers, HeadersInit, Request as uRequest } from 'undici';
 import { URLSearchParams } from 'url';
 import { fromNullableMapping } from '../converters/fromRpcNullable';
 import { fromRpcTypedData } from '../converters/fromRpcTypedData';
@@ -17,7 +16,7 @@ import { isDefined, nonNullProp } from '../utils/nonNull';
 import { extractHttpUserFromHeaders } from './extractHttpUserFromHeaders';
 
 interface InternalHttpRequestInit extends RpcHttpData {
-    undiciRequest?: uRequest;
+    nativeRequest?: Request;
 }
 
 export class HttpRequest implements types.HttpRequest {
@@ -25,14 +24,14 @@ export class HttpRequest implements types.HttpRequest {
     readonly params: HttpRequestParams;
 
     #cachedUser?: HttpRequestUser | null;
-    #uReq: uRequest;
+    #nativeReq: Request;
     #init: InternalHttpRequestInit;
 
     constructor(init: InternalHttpRequestInit) {
         this.#init = init;
 
-        let uReq = init.undiciRequest;
-        if (!uReq) {
+        let nativeReq = init.nativeRequest;
+        if (!nativeReq) {
             const url = nonNullProp(init, 'url');
 
             let body: Buffer | string | undefined;
@@ -42,33 +41,33 @@ export class HttpRequest implements types.HttpRequest {
                 body = init.body.string;
             }
 
-            uReq = new uRequest(url, {
+            nativeReq = new Request(url, {
                 body,
                 method: nonNullProp(init, 'method'),
                 headers: fromNullableMapping(init.nullableHeaders, init.headers),
             });
         }
-        this.#uReq = uReq;
+        this.#nativeReq = nativeReq;
 
         if (init.nullableQuery || init.query) {
             this.query = new URLSearchParams(fromNullableMapping(init.nullableQuery, init.query));
         } else {
-            this.query = new URL(this.#uReq.url).searchParams;
+            this.query = new URL(this.#nativeReq.url).searchParams;
         }
 
         this.params = fromNullableMapping(init.nullableParams, init.params);
     }
 
     get url(): string {
-        return this.#uReq.url;
+        return this.#nativeReq.url;
     }
 
     get method(): string {
-        return this.#uReq.method;
+        return this.#nativeReq.method;
     }
 
     get headers(): Headers {
-        return this.#uReq.headers;
+        return this.#nativeReq.headers;
     }
 
     get user(): HttpRequestUser | null {
@@ -80,36 +79,36 @@ export class HttpRequest implements types.HttpRequest {
     }
 
     get body(): ReadableStream<any> | null {
-        return this.#uReq.body;
+        return this.#nativeReq.body as ReadableStream<any> | null;
     }
 
     get bodyUsed(): boolean {
-        return this.#uReq.bodyUsed;
+        return this.#nativeReq.bodyUsed;
     }
 
     async arrayBuffer(): Promise<ArrayBuffer> {
-        return this.#uReq.arrayBuffer();
+        return this.#nativeReq.arrayBuffer();
     }
 
     async blob(): Promise<Blob> {
-        return this.#uReq.blob();
+        return this.#nativeReq.blob() as Promise<Blob>;
     }
 
     async formData(): Promise<FormData> {
-        return this.#uReq.formData();
+        return this.#nativeReq.formData();
     }
 
     async json(): Promise<unknown> {
-        return this.#uReq.json();
+        return this.#nativeReq.json();
     }
 
     async text(): Promise<string> {
-        return this.#uReq.text();
+        return this.#nativeReq.text();
     }
 
     clone(): HttpRequest {
         const newInit = structuredClone(this.#init);
-        newInit.undiciRequest = this.#uReq.clone();
+        newInit.nativeRequest = this.#nativeReq.clone();
         return new HttpRequest(newInit);
     }
 }
@@ -144,8 +143,10 @@ export function createStreamRequest(
         headers = <HeadersInit>headersData;
     }
 
-    const uReq = new uRequest(url, {
-        body,
+    const nativeReq = new Request(url, {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        body: body as any,
+        // @ts-expect-error duplex is needed for streaming but not in all TypeScript versions
         duplex: 'half',
         method: nonNullProp(proxyReq, 'method'),
         headers,
@@ -159,7 +160,7 @@ export function createStreamRequest(
     }
 
     return new HttpRequest({
-        undiciRequest: uReq,
+        nativeRequest: nativeReq,
         params,
     });
 }

--- a/src/http/HttpResponse.ts
+++ b/src/http/HttpResponse.ts
@@ -5,32 +5,37 @@ import * as types from '@azure/functions';
 import { HttpResponseInit } from '@azure/functions';
 import { Blob } from 'buffer';
 import { ReadableStream } from 'stream/web';
-import { FormData, Headers, Response as uResponse, ResponseInit as uResponseInit } from 'undici';
 import { isDefined } from '../utils/nonNull';
 
 interface InternalHttpResponseInit extends HttpResponseInit {
-    undiciResponse?: uResponse;
+    nativeResponse?: Response;
 }
 
 export class HttpResponse implements types.HttpResponse {
     readonly cookies: types.Cookie[];
     readonly enableContentNegotiation: boolean;
 
-    #uRes: uResponse;
+    #nativeRes: Response;
     #init: InternalHttpResponseInit;
 
     constructor(init?: InternalHttpResponseInit) {
         init ??= {};
         this.#init = init;
 
-        if (init.undiciResponse) {
-            this.#uRes = init.undiciResponse;
+        if (init.nativeResponse) {
+            this.#nativeRes = init.nativeResponse;
         } else {
-            const uResInit: uResponseInit = { status: init.status, headers: init.headers };
+            const resInit: ResponseInit = { status: init.status, headers: init.headers };
             if (isDefined(init.jsonBody)) {
-                this.#uRes = uResponse.json(init.jsonBody, uResInit);
+                // Response.json is not available in all versions, so we create it manually
+                const jsonBody = JSON.stringify(init.jsonBody);
+                const jsonHeaders = new Headers(resInit.headers);
+                if (!jsonHeaders.has('content-type')) {
+                    jsonHeaders.set('content-type', 'application/json');
+                }
+                this.#nativeRes = new Response(jsonBody, { ...resInit, headers: jsonHeaders });
             } else {
-                this.#uRes = new uResponse(init.body, uResInit);
+                this.#nativeRes = new Response(init.body, resInit);
             }
         }
 
@@ -39,44 +44,44 @@ export class HttpResponse implements types.HttpResponse {
     }
 
     get status(): number {
-        return this.#uRes.status;
+        return this.#nativeRes.status;
     }
 
     get headers(): Headers {
-        return this.#uRes.headers;
+        return this.#nativeRes.headers;
     }
 
     get body(): ReadableStream<any> | null {
-        return this.#uRes.body;
+        return this.#nativeRes.body as ReadableStream<any> | null;
     }
 
     get bodyUsed(): boolean {
-        return this.#uRes.bodyUsed;
+        return this.#nativeRes.bodyUsed;
     }
 
     async arrayBuffer(): Promise<ArrayBuffer> {
-        return this.#uRes.arrayBuffer();
+        return this.#nativeRes.arrayBuffer();
     }
 
     async blob(): Promise<Blob> {
-        return this.#uRes.blob();
+        return this.#nativeRes.blob() as Promise<Blob>;
     }
 
     async formData(): Promise<FormData> {
-        return this.#uRes.formData();
+        return this.#nativeRes.formData();
     }
 
     async json(): Promise<unknown> {
-        return this.#uRes.json();
+        return this.#nativeRes.json();
     }
 
     async text(): Promise<string> {
-        return this.#uRes.text();
+        return this.#nativeRes.text();
     }
 
     clone(): HttpResponse {
         const newInit = structuredClone(this.#init);
-        newInit.undiciResponse = this.#uRes.clone();
+        newInit.nativeResponse = this.#nativeRes.clone();
         return new HttpResponse(newInit);
     }
 }

--- a/src/http/extractHttpUserFromHeaders.ts
+++ b/src/http/extractHttpUserFromHeaders.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { HttpRequestUser } from '@azure/functions';
-import { Headers } from 'undici';
 import { nonNullValue } from '../utils/nonNull';
 
 /* grandfathered in. Should fix when possible */

--- a/test/converters/toRpcHttp.test.ts
+++ b/test/converters/toRpcHttp.test.ts
@@ -5,7 +5,6 @@ import 'mocha';
 import * as chai from 'chai';
 import { expect } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { Headers } from 'undici';
 import { toRpcHttp } from '../../src/converters/toRpcHttp';
 import { HttpResponse } from '../../src/http/HttpResponse';
 

--- a/test/http/HttpRequest.test.ts
+++ b/test/http/HttpRequest.test.ts
@@ -5,7 +5,6 @@ import 'mocha';
 import * as chai from 'chai';
 import { expect } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { File } from 'undici';
 import { HttpRequest } from '../../src/http/HttpRequest';
 
 chai.use(chaiAsPromised);
@@ -94,7 +93,7 @@ world
 
             const parsedForm = await req.formData();
             expect(parsedForm.has('myfile')).to.equal(true);
-            const file = <File>parsedForm.get('myfile');
+            const file = parsedForm.get('myfile') as File;
             expect(file.name).to.equal('test.txt');
             expect(file.type).to.equal('text/plain');
             expect(await file.text()).to.equal(`hello\r\nworld`);
@@ -135,7 +134,8 @@ value2
             const contentTypes = ['application/octet-stream', 'application/json', 'text/plain', 'invalid'];
             for (const contentType of contentTypes) {
                 const req = createFormRequest('', contentType);
-                await expect(req.formData()).to.eventually.be.rejectedWith(/Could not parse content as FormData/i);
+                // Native fetch API has different error message than undici
+                await expect(req.formData()).to.eventually.be.rejectedWith(/Content-Type.*not.*one of|Could not parse content as FormData/i);
             }
         });
     });

--- a/test/http/HttpRequest.test.ts
+++ b/test/http/HttpRequest.test.ts
@@ -135,7 +135,9 @@ value2
             for (const contentType of contentTypes) {
                 const req = createFormRequest('', contentType);
                 // Native fetch API has different error message than undici
-                await expect(req.formData()).to.eventually.be.rejectedWith(/Content-Type.*not.*one of|Could not parse content as FormData/i);
+                await expect(req.formData()).to.eventually.be.rejectedWith(
+                    /Content-Type.*not.*one of|Could not parse content as FormData/i
+                );
             }
         });
     });

--- a/test/http/extractHttpUserFromHeaders.test.ts
+++ b/test/http/extractHttpUserFromHeaders.test.ts
@@ -4,7 +4,6 @@
 import 'mocha';
 import { HttpRequestUser } from '@azure/functions';
 import { expect } from 'chai';
-import { Headers } from 'undici';
 import { extractHttpUserFromHeaders } from '../../src/http/extractHttpUserFromHeaders';
 
 describe('Extract Http User Claims Principal from Headers', () => {

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -3,7 +3,6 @@
 
 import { Blob } from 'buffer';
 import { ReadableStream } from 'stream/web';
-import { BodyInit, FormData, Headers, HeadersInit } from 'undici';
 import { URLSearchParams } from 'url';
 import { FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';


### PR DESCRIPTION
Description:

Removed undici dependency completely
Replaced all undici usage with native Node.js fetch API (Request, Response, Headers, FormData, File).

Reason:

Headers is now a global type from Node.js's built-in fetch API (available in Node.js 18+). When we removed undici, we didn't need to change the Headers type reference because Node.js provides the same Headers class natively - it's automatically available in the global scope just like Request, Response, and FormData. The type definition comes from @types/node@^20.0.0 which includes all the native fetch API types, so TypeScript recognizes it without any imports.