### PR TITLE
Fixing the verbatimModuleSyntax issue

### DIFF
--- a/azure-pipelines/code-mirror.yml
+++ b/azure-pipelines/code-mirror.yml
@@ -2,6 +2,7 @@ trigger:
     branches:
         include:
             - v*.x
+            - alias/*
 
 resources:
     repositories:

--- a/src/utils/toolProperties.ts
+++ b/src/utils/toolProperties.ts
@@ -111,9 +111,9 @@ export class ToolPropertyBuilder implements IToolPropertyBuilder {
     /**
      * Mark the property as optional
      */
-    optional(): McpToolProperty {
+    optional(): IToolPropertyBuilder {
         this.property.isRequired = false;
-        return this.buildInternal();
+        return this;
     }
 
     /**
@@ -122,24 +122,6 @@ export class ToolPropertyBuilder implements IToolPropertyBuilder {
     asArray(): ToolPropertyBuilder {
         this.property.isArray = true;
         return this;
-    }
-
-    /**
-     * Build the final McpToolProperty object
-     * @private
-     */
-    private buildInternal(): McpToolProperty {
-        if (!this.property.propertyType) {
-            throw new Error('Property type must be specified (use .string(), .number(), etc.)');
-        }
-
-        return {
-            propertyName: '', // Will be set by the consumer based on the key
-            propertyType: this.property.propertyType,
-            description: this.property.description || '', // Default to empty string if not provided
-            isRequired: this.property.isRequired ?? true, // Default to true (required by default)
-            isArray: this.property.isArray ?? false,
-        };
     }
 }
 

--- a/src/utils/toolProperties.ts
+++ b/src/utils/toolProperties.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import type { Args, McpToolProperty } from '../../types/mcpTool';
+import type { IToolPropertyBuilder } from '../../types/toolPropertyBuilder';
 
 /**
  * Fluent API builder for creating MCP Tool properties
- * Also implements McpToolProperty interface to work seamlessly in object contexts
+ * Implements the IToolPropertyBuilder interface to ensure type consistency
  */
-export class ToolPropertyBuilder implements McpToolProperty {
+export class ToolPropertyBuilder implements IToolPropertyBuilder {
     private property: Partial<McpToolProperty> = {};
 
     // Implement McpToolProperty interface with getters

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,8 @@ export * from './warmup';
 export * from './webpubsub';
 
 // Export toolProp for fluent tool properties API
-export { arg } from '../src/utils/toolProperties';
+export { arg } from './toolProperties';
+export type { IToolPropertyBuilder } from './toolPropertyBuilder';
 
 /**
  * Void if no `return` output is registered

--- a/types/toolProperties.d.ts
+++ b/types/toolProperties.d.ts
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { Args, McpToolProperty } from './mcpTool';
+import type { IToolPropertyBuilder } from './toolPropertyBuilder';
+
+/**
+ * Fluent API builder for creating MCP Tool properties
+ * Implements IToolPropertyBuilder interface to ensure consistency
+ */
+export declare class ToolPropertyBuilder implements IToolPropertyBuilder {
+    get propertyType(): string;
+    get description(): string;
+    get isRequired(): boolean;
+    get isArray(): boolean;
+
+    string(): IToolPropertyBuilder;
+    double(): IToolPropertyBuilder;
+    long(): IToolPropertyBuilder;
+    number(): IToolPropertyBuilder;
+    boolean(): IToolPropertyBuilder;
+    object(): IToolPropertyBuilder;
+    integer(): IToolPropertyBuilder;
+    datetime(): IToolPropertyBuilder;
+    describe(description: string): IToolPropertyBuilder;
+    optional(): McpToolProperty;
+    asArray(): IToolPropertyBuilder;
+}
+
+/**
+ * Factory function to create a new tool property builder
+ *
+ * @example
+ * ```typescript
+ * const toolProperties = {
+ *   snippetName: arg
+ *     .string()
+ *     .describe("Some Description"),
+ *
+ *   optionalField: arg
+ *     .number()
+ *     .describe("Optional number field")
+ *     .optional(),
+ * };
+ * ```
+ */
+export declare const arg: {
+    string(): IToolPropertyBuilder;
+    integer(): IToolPropertyBuilder;
+    number(): IToolPropertyBuilder;
+    long(): IToolPropertyBuilder;
+    double(): IToolPropertyBuilder;
+    boolean(): IToolPropertyBuilder;
+    datetime(): IToolPropertyBuilder;
+    object(): IToolPropertyBuilder;
+};
+
+/**
+ * Convert a tool properties object to McpToolProperty array
+ * @param args - Object with property names as keys and ToolProperty as values
+ * @returns Array of McpToolProperty objects with propertyName set correctly
+ */
+export declare function convertToolProperties(args: Args): McpToolProperty[];
+
+/**
+ * Type guard to check if properties are in toolProp format
+ */
+export declare function isToolProperties(properties: unknown): properties is Args;
+
+/**
+ * Normalize tool properties to McpToolProperty array format
+ * Supports both legacy array format and new toolProp object format
+ */
+export declare function normalizeToolProperties(
+    properties: McpToolProperty[] | Args | undefined
+): McpToolProperty[] | undefined;

--- a/types/toolProperties.d.ts
+++ b/types/toolProperties.d.ts
@@ -23,7 +23,7 @@ export declare class ToolPropertyBuilder implements IToolPropertyBuilder {
     integer(): IToolPropertyBuilder;
     datetime(): IToolPropertyBuilder;
     describe(description: string): IToolPropertyBuilder;
-    optional(): McpToolProperty;
+    optional(): IToolPropertyBuilder;
     asArray(): IToolPropertyBuilder;
 }
 

--- a/types/toolPropertyBuilder.d.ts
+++ b/types/toolPropertyBuilder.d.ts
@@ -62,7 +62,7 @@ export interface IToolPropertyBuilder extends Omit<Arg, never> {
     /**
      * Mark the property as optional
      */
-    optional(): Arg;
+    optional(): IToolPropertyBuilder;
 
     /**
      * Mark the property as an array type

--- a/types/toolPropertyBuilder.d.ts
+++ b/types/toolPropertyBuilder.d.ts
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { Arg } from './mcpTool';
+
+/**
+ * Interface for the fluent API builder for creating MCP Tool properties
+ * This acts as a bridge between the implementation and type declarations
+ */
+export interface IToolPropertyBuilder extends Omit<Arg, never> {
+    readonly propertyType: string;
+    readonly description: string;
+    readonly isRequired: boolean;
+    readonly isArray: boolean;
+
+    /**
+     * Set the property type to string
+     */
+    string(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to double
+     */
+    double(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to long
+     */
+    long(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to number
+     */
+    number(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to boolean
+     */
+    boolean(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to object
+     */
+    object(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to integer
+     */
+    integer(): IToolPropertyBuilder;
+
+    /**
+     * Set the property type to datetime
+     */
+    datetime(): IToolPropertyBuilder;
+
+    /**
+     * Set the description for the property
+     * @param description - Description of the property's purpose
+     */
+    describe(description: string): IToolPropertyBuilder;
+
+    /**
+     * Mark the property as optional
+     */
+    optional(): Arg;
+
+    /**
+     * Mark the property as an array type
+     */
+    asArray(): IToolPropertyBuilder;
+}


### PR DESCRIPTION
Overivew
When library .d.ts files import .ts files, those .ts files are included in the compilation step of the user projects. For example, since index.d.ts [imports toolProperties.ts here](https://github.com/Azure/azure-functions-nodejs-library/blob/70bcdf41e8f7319c0ec16a84472d6fd38582fcfc/types/index.d.ts#L34), toolProperties.ts will be compiles as part of the user project

This is problematic since file may not compile under tsconfig.json settings of the user

For example, this library is targets CJS, but uses ESM syntax (export). If users use verbatimModuleSyntax: true - which requires that CJS files use CJS syntax - their compilation will fail, with no easy fix

Similarly, if users if users use any strict* option this project doesn't, toolProperties.ts may not compile

Effectively, toolProperties.ts of this library limits what tsconfig.json settings users can use

Expected behavior
Library's .d.ts files may import only other .d.ts files, but not .ts files

Actual behavior
index.d.ts [imports toolProperties.ts here](https://github.com/Azure/azure-functions-nodejs-library/blob/70bcdf41e8f7319c0ec16a84472d6fd38582fcfc/types/index.d.ts#L34)

Example user project that fails to compile due to this: https://github.com/azerum/azure-functions-type-check-bug

Suggested fix
Generate .d.ts file for toolProperties.ts and export that. I am not familiar with why .d.ts files of this library are written manually and not generated from .ts files, I assume there must be a good reason..