### PR TITLE
Removing Long from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
     "name": "@azure/functions",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.11.0",
+            "version": "4.11.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0",
-                "long": "^4.0.0"
+                "cookie": "^0.7.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -39,6 +38,7 @@
                 "fork-ts-checker-webpack-plugin": "^7.2.13",
                 "fs-extra": "^10.0.1",
                 "globby": "^11.0.0",
+                "long": "^4.0.0",
                 "minimist": "^1.2.6",
                 "mocha": "^11.1.0",
                 "mocha-junit-reporter": "^2.0.2",
@@ -4342,6 +4342,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
             "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",
@@ -42,8 +42,7 @@
     },
     "dependencies": {
         "@azure/functions-extensions-base": "0.2.0",
-        "cookie": "^0.7.0",
-        "long": "^4.0.0"
+        "cookie": "^0.7.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",
@@ -71,6 +70,7 @@
         "fork-ts-checker-webpack-plugin": "^7.2.13",
         "fs-extra": "^10.0.1",
         "globby": "^11.0.0",
+        "long": "^4.0.0",
         "minimist": "^1.2.6",
         "mocha": "^11.1.0",
         "mocha-junit-reporter": "^2.0.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.11.0';
+export const version = '4.11.1';
 
 export const returnBindingKey = '$return';


### PR DESCRIPTION
We use long only as a devDependency and do not rely on it at runtime, so we’re moving it to devDependencies.

We will validate whether this change has any impact on existing apps during integration testing. If a customer’s app depends on long, they will need to explicitly declare it in their own package.json.