### PR TITLE
Fixing the missing type issue with the library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "@azure/functions",
-    "version": "4.11.1",
+    "version": "4.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.11.1",
+            "version": "4.11.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "undici-types": "^7.20.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -627,6 +628,13 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/node/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -6562,10 +6570,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true,
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.20.0.tgz",
+            "integrity": "sha512-PZDAAlMkNw5ZzN/ebfyrwzrMWfIf7Jbn9iM/I6SF456OKrb2wnfqVowaxEY/cMAM8MjFu1zhdpJyA0L+rTYwNw==",
             "license": "MIT"
         },
         "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     },
     "dependencies": {
         "@azure/functions-extensions-base": "0.2.0",
-        "cookie": "^0.7.0"
+        "cookie": "^0.7.0",
+        "undici-types": "^7.20.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/src/http/HttpRequest.ts
+++ b/src/http/HttpRequest.ts
@@ -153,7 +153,7 @@ export function createStreamRequest(
         duplex: 'half',
         method: nonNullProp(proxyReq, 'method'),
         headers,
-    });
+    } as RequestInit);
 
     const params: Record<string, string> = {};
     for (const [key, rpcValue] of Object.entries(rpcParams)) {

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -4,6 +4,7 @@
 import { Blob } from 'buffer';
 import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
+import { FormData, Headers } from 'undici-types';
 import { URLSearchParams } from 'url';
 import { FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger } from './index';
 import { InvocationContext } from './InvocationContext';


### PR DESCRIPTION
PR: Fix missing FormData and Headers type definitions

Problem
Customers using this library were encountering TypeScript compilation errors when importing @azure/functions:

types/http.d.ts:23:7 - error TS2304: Cannot find name 'FormData'.
types/http.d.ts:34:31 - error TS2304: Cannot find name 'Headers'.
types/http.d.ts:120:23 - error TS2304: Cannot find name 'Headers'.
types/http.d.ts:162:38 - error TS2304: Cannot find name 'FormData'.
types/http.d.ts:279:23 - error TS2304: Cannot find name 'Headers'.
types/http.d.ts:316:38 - error TS2304: Cannot find name 'FormData'.

The FormData and Headers types are Web API types used in the HTTP type definitions but were not properly imported. These types are part of Node.js's native fetch API (available since Node.js 18) but TypeScript requires explicit type definitions.

Solution
1. Added undici-types as an explicit dependency 28kb of library dependency.


Why undici-types?


- It's the official types package for Node.js's native fetch API (based on undici)
- It's a types-only package (~28 KB compressed, ~114 KB unpacked) with zero runtime footprint
- Previously existed only as a transitive dependency of @types/node which caused resolution issues in some customer configurations (pnpm, yarn PnP, strict moduleResolution)
- Adding it as an explicit dependency ensures customers can resolve the types regardless of their package manager or TypeScript configuration