### PR TITLE
Adding the AsyncIterable type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.11.1",
+    "version": "4.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.11.1",
+            "version": "4.11.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",

--- a/test/http/HttpResponse.test.ts
+++ b/test/http/HttpResponse.test.ts
@@ -406,6 +406,7 @@ describe('HttpResponse', () => {
             const encoder = new TextEncoder();
 
             async function* generateChunks(): AsyncIterable<Uint8Array> {
+                await Promise.resolve();
                 yield encoder.encode('Async ');
                 yield encoder.encode('iterable ');
                 yield encoder.encode('content');
@@ -422,6 +423,7 @@ describe('HttpResponse', () => {
             const chunks = ['chunk1', 'chunk2', 'chunk3'];
 
             async function* generateChunks(): AsyncIterable<Uint8Array> {
+                await Promise.resolve();
                 for (const chunk of chunks) {
                     yield encoder.encode(chunk);
                 }

--- a/test/http/HttpResponse.test.ts
+++ b/test/http/HttpResponse.test.ts
@@ -400,6 +400,55 @@ describe('HttpResponse', () => {
             });
             expect(await res.text()).to.equal('Hello from stream');
         });
+
+        it('AsyncIterable<Uint8Array> body', async () => {
+            // AsyncIterable is useful for streaming responses (e.g., AI chat responses)
+            const encoder = new TextEncoder();
+
+            async function* generateChunks(): AsyncIterable<Uint8Array> {
+                yield encoder.encode('Async ');
+                yield encoder.encode('iterable ');
+                yield encoder.encode('content');
+            }
+
+            const res = new HttpResponse({
+                body: generateChunks(),
+            });
+            expect(await res.text()).to.equal('Async iterable content');
+        });
+
+        it('AsyncIterable<Uint8Array> body with multiple chunks', async () => {
+            const encoder = new TextEncoder();
+            const chunks = ['chunk1', 'chunk2', 'chunk3'];
+
+            async function* generateChunks(): AsyncIterable<Uint8Array> {
+                for (const chunk of chunks) {
+                    yield encoder.encode(chunk);
+                }
+            }
+
+            const res = new HttpResponse({
+                body: generateChunks(),
+            });
+            expect(await res.text()).to.equal('chunk1chunk2chunk3');
+        });
+
+        it('AsyncIterable<Uint8Array> body with delayed chunks', async () => {
+            const encoder = new TextEncoder();
+
+            async function* generateDelayedChunks(): AsyncIterable<Uint8Array> {
+                yield encoder.encode('first');
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                yield encoder.encode('second');
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                yield encoder.encode('third');
+            }
+
+            const res = new HttpResponse({
+                body: generateDelayedChunks(),
+            });
+            expect(await res.text()).to.equal('firstsecondthird');
+        });
     });
 
     describe('HttpHeadersInit types', () => {

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -12,7 +12,7 @@ import { InvocationContext } from './InvocationContext';
  * Represents the body types that can be used in an HTTP response.
  * This is a local definition to avoid dependency on lib.dom.
  * Compatible with Node.js native Fetch API body types.
- * Includes Node.js Readable streams for HTTP streaming scenarios.
+ * Includes Node.js Readable streams and AsyncIterable for HTTP streaming scenarios.
  */
 export type HttpResponseBodyInit =
     | ReadableStream
@@ -20,6 +20,7 @@ export type HttpResponseBodyInit =
     | Blob
     | ArrayBufferView
     | ArrayBuffer
+    | AsyncIterable<Uint8Array>
     | FormData
     | URLSearchParams
     | string


### PR DESCRIPTION
PR: Add AsyncIterable<Uint8Array> support to HttpResponseBodyInit

Description:
Adds AsyncIterable<Uint8Array> as a valid body type for HTTP responses. This enables streaming response scenarios such as AI chat completions, where data is returned incrementally via async generators. Customers can now pass async iterables directly to HttpResponseInit.body without needing to convert them to ReadableStream first.

