### PR TITLE
Adding the Structure content changes

### DIFF
--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -18,6 +18,7 @@ import { fromRpcRetryContext, fromRpcTraceContext } from './converters/fromRpcCo
 import { fromRpcTriggerMetadata } from './converters/fromRpcTriggerMetadata';
 import { fromRpcTypedData } from './converters/fromRpcTypedData';
 import { toCamelCaseValue } from './converters/toCamelCase';
+import { toMcpToolResult } from './converters/toMcpToolResult';
 import { toRpcHttp } from './converters/toRpcHttp';
 import { toRpcTypedData } from './converters/toRpcTypedData';
 import { AzFuncSystemError } from './errors';
@@ -25,7 +26,7 @@ import { waitForProxyRequest } from './http/httpProxy';
 import { createStreamRequest } from './http/HttpRequest';
 import { InvocationContext } from './InvocationContext';
 import { enableHttpStream } from './setup';
-import { isHttpTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
+import { isHttpTrigger, isMcpToolTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
 import { isDefined, nonNullProp, nonNullValue } from './utils/nonNull';
 
 export class InvocationModel implements coreTypes.InvocationModel {
@@ -118,7 +119,9 @@ export class InvocationModel implements coreTypes.InvocationModel {
         for (const [name, binding] of Object.entries(this.#bindings)) {
             if (binding.direction === 'out') {
                 if (name === returnBindingKey) {
-                    response.returnValue = await this.#convertOutput(context.invocationId, binding, result);
+                    response.returnValue = isMcpToolTrigger(this.#triggerType)
+                        ? this.#convertMcpToolReturnValue(result)
+                        : await this.#convertOutput(context.invocationId, binding, result);
                     usedReturnValue = true;
                 } else {
                     const outputValue = await this.#convertOutput(
@@ -138,7 +141,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
         // but e.g., Durable uses this to pass orchestrator state back to the Durable extension, w/o
         // an explicit output binding. See here for more details: https://github.com/Azure/azure-functions-nodejs-library/pull/25
         if (!usedReturnValue && !isHttpTrigger(this.#triggerType)) {
-            response.returnValue = toRpcTypedData(result);
+            response.returnValue = this.#convertMcpToolReturnValue(result);
         }
 
         return response;
@@ -154,6 +157,22 @@ export class InvocationModel implements coreTypes.InvocationModel {
         } else {
             return toRpcTypedData(value);
         }
+    }
+
+    #convertMcpToolReturnValue(value: unknown): RpcTypedData | null | undefined {
+        if (!isMcpToolTrigger(this.#triggerType)) {
+            return toRpcTypedData(value);
+        }
+
+        const converted = toMcpToolResult(value);
+
+        if (converted === null || converted === undefined) {
+            return converted;
+        }
+
+        return {
+            string: typeof converted === 'string' ? converted : JSON.stringify(converted),
+        };
     }
 
     #log(level: RpcLogLevel, logCategory: RpcLogCategory, ...args: unknown[]): void {

--- a/src/converters/toMcpToolResult.ts
+++ b/src/converters/toMcpToolResult.ts
@@ -1,0 +1,261 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { McpToolResult } from '@azure/functions';
+import { shouldCreateStructuredContentMarker } from '../utils/mcpContentMarker';
+
+interface TextContentBlock {
+    type: 'text';
+    text: string;
+}
+
+const multiContentResultType = 'multi_content_result';
+const textContentResultType = 'text';
+const directContentBlockTypes = new Set(['text', 'image', 'audio', 'resource', 'resource_link']);
+
+interface CallToolResultLike {
+    content: unknown[];
+    structuredContent?: unknown;
+}
+
+/**
+ * Converts a tool return value into a normalized MCP tool result.
+ *
+ * Supported inputs include CallToolResult-like objects, direct content blocks,
+ * arrays of content blocks, existing MCP results, and plain values.
+ */
+export function toMcpToolResult(result: unknown): McpToolResult | null | undefined {
+    if (result === null || result === undefined) {
+        return result;
+    }
+
+    if (isCallToolResult(result)) {
+        const callToolResult = ensureCallToolResultHasTextContent(result);
+        const normalizedBlocks = normalizeContentBlocks(callToolResult.content);
+        const mcpResult = createMcpToolResultFromContentBlocks(normalizedBlocks);
+        mcpResult.structuredContent = serializeStructuredContent(callToolResult.structuredContent);
+        return mcpResult;
+    }
+
+    if (isContentBlockArray(result)) {
+        const normalizedBlocks = normalizeContentBlocks(result);
+        const mcpResult = createMcpToolResultFromContentBlocks(normalizedBlocks);
+        return mcpResult;
+    }
+
+    if (isContentBlock(result)) {
+        const normalizedBlock = normalizeContentBlock(result);
+        const mcpResult = createMcpToolResultFromContentBlocks([normalizedBlock]);
+        return mcpResult;
+    }
+
+    if (isMcpToolResult(result)) {
+        return normalizeMcpToolResult(result);
+    }
+
+    const text = typeof result === 'string' ? result : JSON.stringify(result);
+    const mcpResult: McpToolResult = {
+        type: textContentResultType,
+        content: JSON.stringify({ type: textContentResultType, text } as TextContentBlock),
+    };
+
+    if (shouldCreateStructuredContentMarker(result)) {
+        mcpResult.structuredContent = JSON.stringify(result);
+    }
+
+    return mcpResult;
+}
+
+/**
+ * Creates an MCP tool result from one or many normalized content blocks.
+ * A single block preserves its own type; multiple blocks become multi_content_result.
+ */
+function createMcpToolResultFromContentBlocks(content: unknown[]): McpToolResult {
+    if (content.length === 1) {
+        const [block] = content;
+        const blockType = getContentBlockType(block);
+        return {
+            type: blockType,
+            content: JSON.stringify(block),
+        };
+    }
+
+    return {
+        type: multiContentResultType,
+        content: JSON.stringify(content),
+    };
+}
+
+/**
+ * Normalizes all blocks in a content array.
+ */
+function normalizeContentBlocks(content: unknown[]): unknown[] {
+    return content.map((block) => normalizeContentBlock(block));
+}
+
+/**
+ * Normalizes one content block and base64-encodes binary payloads for image/audio.
+ */
+function normalizeContentBlock(block: unknown): unknown {
+    if (!block || typeof block !== 'object') {
+        return block;
+    }
+
+    const contentBlock = { ...(block as Record<string, unknown>) };
+    const type = getContentBlockType(contentBlock);
+
+    if ((type === 'image' || type === 'audio') && 'data' in contentBlock) {
+        contentBlock.data = normalizeBinaryData(contentBlock.data);
+    }
+
+    return contentBlock;
+}
+
+/**
+ * Converts binary-like values into base64 strings when possible.
+ */
+function normalizeBinaryData(data: unknown): unknown {
+    if (typeof data === 'string' || data === null || data === undefined) {
+        return data;
+    }
+
+    if (Buffer.isBuffer(data)) {
+        return data.toString('base64');
+    }
+
+    if (ArrayBuffer.isView(data)) {
+        const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        return Buffer.from(view).toString('base64');
+    }
+
+    if (data instanceof ArrayBuffer) {
+        return Buffer.from(new Uint8Array(data)).toString('base64');
+    }
+
+    return data;
+}
+
+/**
+ * Checks whether a value already looks like an MCP tool result payload.
+ */
+function isMcpToolResult(value: unknown): value is McpToolResult {
+    return (
+        !!value &&
+        typeof value === 'object' &&
+        typeof (value as McpToolResult).type === 'string' &&
+        ('content' in (value as Record<string, unknown>) || 'structuredContent' in (value as Record<string, unknown>))
+    );
+}
+
+/**
+ * Checks whether a value is a single direct content block.
+ */
+function isContentBlock(value: unknown): value is Record<string, unknown> & { type: string } {
+    return (
+        !!value &&
+        typeof value === 'object' &&
+        typeof (value as { type?: unknown }).type === 'string' &&
+        !('content' in (value as Record<string, unknown>)) &&
+        directContentBlockTypes.has((value as { type: string }).type)
+    );
+}
+
+/**
+ * Checks whether a value is a non-empty array of direct content blocks.
+ */
+function isContentBlockArray(value: unknown): value is Array<Record<string, unknown> & { type: string }> {
+    return Array.isArray(value) && value.length > 0 && value.every((item) => isContentBlock(item));
+}
+
+/**
+ * Normalizes an existing MCP tool result by serializing non-string fields.
+ */
+function normalizeMcpToolResult(result: McpToolResult): McpToolResult {
+    return {
+        ...result,
+        content: serializeOptionalContent(result.content),
+        structuredContent: serializeStructuredContent(result.structuredContent),
+    };
+}
+
+/**
+ * Serializes optional content when present and non-string.
+ */
+function serializeOptionalContent(content: unknown): string | undefined {
+    if (content === null || content === undefined) {
+        return undefined;
+    }
+
+    if (typeof content === 'string') {
+        return content;
+    }
+
+    return JSON.stringify(content);
+}
+
+/**
+ * Checks whether a value matches the minimal CallToolResult shape.
+ */
+function isCallToolResult(value: unknown): value is CallToolResultLike {
+    return !!value && typeof value === 'object' && Array.isArray((value as { content?: unknown }).content);
+}
+
+/**
+ * Ensures CallToolResult content includes a text block when structuredContent exists.
+ *
+ * Some MCP clients require text in addition to structured content for display.
+ */
+function ensureCallToolResultHasTextContent(result: CallToolResultLike): CallToolResultLike {
+    if (
+        result.structuredContent === null ||
+        result.structuredContent === undefined ||
+        hasTextContentBlock(result.content)
+    ) {
+        return result;
+    }
+
+    const fallbackText =
+        typeof result.structuredContent === 'string'
+            ? result.structuredContent
+            : JSON.stringify(result.structuredContent);
+
+    return {
+        ...result,
+        content: [...result.content, { type: textContentResultType, text: fallbackText }],
+    };
+}
+
+/**
+ * Returns a content block type, defaulting to text for malformed blocks.
+ */
+function getContentBlockType(block: unknown): string {
+    if (block && typeof block === 'object' && typeof (block as { type?: unknown }).type === 'string') {
+        return (block as { type: string }).type;
+    }
+
+    return textContentResultType;
+}
+
+/**
+ * Returns true when at least one content block is a text block.
+ */
+function hasTextContentBlock(content: unknown[]): boolean {
+    return content.some((block) => {
+        return !!block && typeof block === 'object' && (block as { type?: unknown }).type === textContentResultType;
+    });
+}
+
+/**
+ * Serializes structured content when present and non-string.
+ */
+function serializeStructuredContent(content: unknown): string | undefined {
+    if (content === null || content === undefined) {
+        return undefined;
+    }
+
+    if (typeof content === 'string') {
+        return content;
+    }
+
+    return JSON.stringify(content);
+}

--- a/src/converters/toMcpToolTriggerOptionsToRpc.ts
+++ b/src/converters/toMcpToolTriggerOptionsToRpc.ts
@@ -31,11 +31,27 @@ export function converToMcpToolTriggerOptionsToRpc(
         }
     }
 
+    let validatedResultSchema: string | undefined;
+    if (
+        mcpToolTriggerOptions.resultSchema !== undefined &&
+        typeof mcpToolTriggerOptions.resultSchema === 'string' &&
+        mcpToolTriggerOptions.resultSchema.trim() !== ''
+    ) {
+        try {
+            JSON.parse(mcpToolTriggerOptions.resultSchema);
+            validatedResultSchema = mcpToolTriggerOptions.resultSchema;
+        } catch (e) {
+            throw new Error('MCP Tool trigger "resultSchema" must be a valid JSON string.');
+        }
+    }
+
     // Base object for the return value - metadata is independent of toolProperties
     const baseResult = {
         toolName: mcpToolTriggerOptions.toolName,
         description: mcpToolTriggerOptions.description,
+        useResultSchema: true,
         ...(validatedMetadata !== undefined && { metadata: validatedMetadata }),
+        ...(validatedResultSchema !== undefined && { resultSchema: validatedResultSchema }),
     };
 
     // Try to normalize tool properties first (handles both array and fluent formats)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { InvocationContext } from './InvocationContext';
 export * as output from './output';
 export * as trigger from './trigger';
 export { Disposable } from './utils/Disposable';
+export { McpContent } from './utils/mcpContentMarker';
 export { arg } from './utils/toolProperties';
 
 export enum SqlChangeOperation {

--- a/src/utils/isTrigger.ts
+++ b/src/utils/isTrigger.ts
@@ -12,3 +12,7 @@ export function isHttpTrigger(typeName: string | undefined | null): boolean {
 export function isTimerTrigger(typeName: string | undefined | null): boolean {
     return typeName?.toLowerCase() === 'timertrigger';
 }
+
+export function isMcpToolTrigger(typeName: string | undefined | null): boolean {
+    return typeName?.toLowerCase() === 'mcptooltrigger';
+}

--- a/src/utils/mcpContentMarker.ts
+++ b/src/utils/mcpContentMarker.ts
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Symbol used internally to mark a class/type as an MCP content type.
+ * This allows runtime detection of types that should be serialized as structured content.
+ * @internal
+ */
+const MCP_CONTENT_MARKER = Symbol('__mcp_content__');
+
+type Constructor<T = unknown> = new (...args: any[]) => T;
+
+/**
+ * Marks a class or constructor function as an MCP result type that should be serialized
+ * as structured content.
+ *
+ * When a function returns an instance of a type decorated with this marker,
+ * the result will be serialized as both text content (for backwards compatibility)
+ * and structured content (for clients that support it).
+ *
+ * Example:
+ * ```typescript
+ * @McpContent
+ * class ImageMetadata {
+ *   constructor(public imageId: string, public format: string, public tags: string[]) {}
+ * }
+ *
+ * // Or programmatic form (without experimentalDecorators):
+ * McpContent(ImageMetadata);
+ * ```
+ *
+ * Supported forms:
+ * - `@McpContent`
+ * - `@McpContent()`
+ * - `McpContent(MyClass)`
+ *
+ * @param target - Optional class or constructor function to mark for structured content.
+ * @returns The target class/function or a class decorator.
+ */
+export function McpContent<T extends Constructor>(target: T): T;
+export function McpContent(): <T extends Constructor>(target: T) => T;
+export function McpContent<T extends Constructor>(target?: T): T | (<U extends Constructor>(target: U) => U) {
+    const applyMarker = <U extends Constructor>(ctor: U): U => {
+        Object.defineProperty(ctor.prototype, MCP_CONTENT_MARKER, {
+            value: true,
+            writable: false,
+            enumerable: false,
+            configurable: false,
+        });
+        return ctor;
+    };
+
+    if (target === undefined) {
+        return applyMarker;
+    }
+
+    return applyMarker(target);
+}
+
+/**
+ * Checks if an object's type/class is marked as an MCP content type.
+ *
+ * @param obj - The object or class to check.
+ * @returns True if the object is marked for structured content; otherwise, false.
+ * @internal
+ */
+export function hasMcpContentMarker(obj: unknown): boolean {
+    if (obj === null || obj === undefined) {
+        return false;
+    }
+
+    // Constructor function: check its prototype directly
+    if (typeof obj === 'function') {
+        return (
+            typeof (obj as { prototype?: unknown }).prototype === 'object' &&
+            (obj as { prototype: object }).prototype !== null &&
+            MCP_CONTENT_MARKER in (obj as { prototype: object }).prototype
+        );
+    }
+
+    // Instance: the Symbol will be found on the prototype chain
+    if (typeof obj === 'object') {
+        return MCP_CONTENT_MARKER in obj;
+    }
+
+    return false;
+}
+
+/**
+ * Determines whether structured content should be created for the given object.
+ *
+ * Returns true only when the object's class is explicitly marked with @McpContent.
+ * This follows the marker/decorator pattern used by MCP SDKs:
+ * - Plain objects / interfaces without the marker → text content only
+ * - Class instances marked with McpContent(MyClass) → text + structuredContent
+ *
+ * @param obj - The object to evaluate.
+ * @returns True if structured content should be emitted; otherwise, false.
+ * @internal
+ */
+export function shouldCreateStructuredContentMarker(obj: unknown): boolean {
+    if (obj === null || obj === undefined) {
+        return false;
+    }
+
+    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
+        return false;
+    }
+
+    if (Array.isArray(obj)) {
+        return false;
+    }
+
+    if (
+        obj instanceof Date ||
+        obj instanceof RegExp ||
+        obj instanceof ArrayBuffer ||
+        ArrayBuffer.isView(obj) ||
+        Buffer.isBuffer(obj) ||
+        obj instanceof Set ||
+        obj instanceof Map
+    ) {
+        return false;
+    }
+
+    return hasMcpContentMarker(obj);
+}

--- a/test/InvocationModel.test.ts
+++ b/test/InvocationModel.test.ts
@@ -4,7 +4,7 @@
 import 'mocha';
 import { RpcLogCategory, RpcLogLevel } from '@azure/functions-core';
 import { expect } from 'chai';
-import { InvocationContext } from '../src';
+import { InvocationContext, McpContent } from '../src';
 import { InvocationModel } from '../src/InvocationModel';
 
 function testLog(_level: RpcLogLevel, _category: RpcLogCategory, message: string) {
@@ -106,9 +106,95 @@ describe('InvocationModel', () => {
                 },
                 log: testLog,
             });
-            await expect(model.getArguments()).to.be.rejectedWith(
-                'Failed to find binding "httpTriggerMissing" in bindings "httpTrigger1, $return".'
-            );
+
+            try {
+                await model.getArguments();
+                expect.fail('Expected getArguments() to throw for a missing binding.');
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                expect(message).to.equal(
+                    'Failed to find binding "httpTriggerMissing" in bindings "httpTrigger1, $return".'
+                );
+            }
+        });
+
+        it('MCP trigger with explicit $return serializes as RpcTypedData.string', async () => {
+            const model = new InvocationModel({
+                invocationId: 'mcpInvocId',
+                metadata: {
+                    name: 'mcpFuncName',
+                    bindings: {
+                        mcpToolTrigger1: {
+                            type: 'mcpToolTrigger',
+                            direction: 'in',
+                        },
+                        $return: {
+                            type: 'queue',
+                            direction: 'out',
+                        },
+                    },
+                },
+                request: {},
+                log: testLog,
+            });
+
+            const context = new InvocationContext();
+            const response = await model.getResponse(context, {
+                type: 'image',
+                data: 'YmFzZTY0',
+                mimeType: 'image/png',
+            });
+
+            expect(response.invocationId).to.equal('mcpInvocId');
+            expect(response.outputData).to.deep.equal([]);
+            expect(response.returnValue).to.have.property('string');
+
+            const payload = JSON.parse((response.returnValue as { string: string }).string) as {
+                type: string;
+                content: string;
+            };
+
+            expect(payload.type).to.equal('image');
+            const imageContent = JSON.parse(payload.content) as { type: string; mimeType: string };
+            expect(imageContent.type).to.equal('image');
+            expect(imageContent.mimeType).to.equal('image/png');
+        });
+
+        it('MCP trigger without $return uses fallback and includes structuredContent for marked class', async () => {
+            class MarkedResult {
+                constructor(public id: string) {}
+            }
+            McpContent(MarkedResult);
+
+            const model = new InvocationModel({
+                invocationId: 'mcpFallbackInvocId',
+                metadata: {
+                    name: 'mcpFallbackFuncName',
+                    bindings: {
+                        mcpToolTrigger1: {
+                            type: 'mcpToolTrigger',
+                            direction: 'in',
+                        },
+                    },
+                },
+                request: {},
+                log: testLog,
+            });
+
+            const context = new InvocationContext();
+            const response = await model.getResponse(context, new MarkedResult('r1'));
+
+            expect(response.invocationId).to.equal('mcpFallbackInvocId');
+            expect(response.outputData).to.deep.equal([]);
+            expect(response.returnValue).to.have.property('string');
+
+            const payload = JSON.parse((response.returnValue as { string: string }).string) as {
+                type: string;
+                structuredContent?: string;
+            };
+
+            expect(payload.type).to.equal('text');
+            expect(payload.structuredContent).to.equal(JSON.stringify({ id: 'r1' }));
         });
     });
 });

--- a/test/converters/toMcpToolResult.test.ts
+++ b/test/converters/toMcpToolResult.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
+import { McpContent } from '../../src/utils/mcpContentMarker';
+
+describe('toMcpToolResult', () => {
+    it('returns nullish values as-is', () => {
+        expect(toMcpToolResult(null)).to.equal(null);
+        expect(toMcpToolResult(undefined)).to.equal(undefined);
+    });
+
+    it('wraps primitive string as text content', () => {
+        const result = toMcpToolResult('hello');
+        expect(result).to.not.equal(undefined);
+        expect(result).to.not.equal(null);
+        expect(result?.type).to.equal('text');
+
+        const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
+        expect(content.type).to.equal('text');
+        expect(content.text).to.equal('hello');
+        expect(result?.structuredContent).to.equal(undefined);
+    });
+
+    it('does not emit structuredContent for plain object', () => {
+        const result = toMcpToolResult({ id: 'plain' });
+        expect(result?.type).to.equal('text');
+        expect(result?.structuredContent).to.equal(undefined);
+    });
+
+    it('emits structuredContent for McpContent-marked class instances', () => {
+        class MarkedPayload {
+            constructor(public id: string) {}
+        }
+
+        McpContent(MarkedPayload);
+        const instance = new MarkedPayload('p1');
+        const result = toMcpToolResult(instance);
+
+        expect(result?.type).to.equal('text');
+        expect(result?.structuredContent).to.equal(JSON.stringify(instance));
+    });
+
+    it('converts direct image block and normalizes buffer data to base64', () => {
+        const buffer = Buffer.from('abc');
+        const result = toMcpToolResult({
+            type: 'image',
+            data: buffer,
+            mimeType: 'image/png',
+        });
+
+        expect(result?.type).to.equal('image');
+        const content = JSON.parse(result?.content || '{}') as { type: string; data: string };
+        expect(content.type).to.equal('image');
+        expect(content.data).to.equal(buffer.toString('base64'));
+    });
+
+    it('wraps direct content block arrays as multi_content_result', () => {
+        const result = toMcpToolResult([
+            { type: 'text', text: 'first' },
+            { type: 'image', data: 'ZGF0YQ==', mimeType: 'image/png' },
+        ]);
+
+        expect(result?.type).to.equal('multi_content_result');
+        const content = JSON.parse(result?.content || '[]') as Array<{ type: string }>;
+        expect(content).to.have.length(2);
+        expect(content[0]?.type).to.equal('text');
+        expect(content[1]?.type).to.equal('image');
+    });
+
+    it('adds fallback text block for CallToolResult with structuredContent and no text block', () => {
+        const result = toMcpToolResult({
+            content: [{ type: 'image', data: 'ZGF0YQ==', mimeType: 'image/png' }],
+            structuredContent: { id: 'x1' },
+        });
+
+        expect(result?.type).to.equal('multi_content_result');
+        const content = JSON.parse(result?.content || '[]') as Array<{ type: string; text?: string }>;
+        expect(content).to.have.length(2);
+        expect(content.some((b) => b.type === 'text')).to.equal(true);
+        expect(result?.structuredContent).to.equal(JSON.stringify({ id: 'x1' }));
+    });
+
+    it('normalizes existing McpToolResult when content is not a string', () => {
+        const result = toMcpToolResult({
+            type: 'text',
+            content: { type: 'text', text: 'normalized' },
+        });
+
+        expect(result?.type).to.equal('text');
+        expect(result?.content).to.equal(JSON.stringify({ type: 'text', text: 'normalized' }));
+    });
+
+    it('treats resource_link blocks as direct content blocks', () => {
+        const result = toMcpToolResult({
+            type: 'resource_link',
+            uri: 'https://example.test/resource',
+            name: 'example',
+        });
+
+        expect(result?.type).to.equal('resource_link');
+        const content = JSON.parse(result?.content || '{}') as { type: string; uri: string };
+        expect(content.type).to.equal('resource_link');
+        expect(content.uri).to.equal('https://example.test/resource');
+    });
+});

--- a/test/converters/toMcpToolTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpToolTriggerOptionsToRpc.test.ts
@@ -672,4 +672,44 @@ describe('converToMcpToolTriggerOptionsToRpc', () => {
             expect(result.metadata).to.equal('{"nested": {"key": "value"}, "array": [1, 2, 3], "boolean": true}');
         });
     });
+
+    describe('result schema contract', () => {
+        it('always sets useResultSchema to true', () => {
+            const input: McpToolTriggerOptions = {
+                toolName: 'schema-enabled-tool',
+                description: 'Always enables useResultSchema',
+                toolProperties: [],
+            };
+
+            const result = converToMcpToolTriggerOptionsToRpc(input);
+            expect(result.useResultSchema).to.equal(true);
+        });
+
+        it('passes through valid resultSchema JSON', () => {
+            const resultSchema = '{"type":"object","properties":{"id":{"type":"string"}}}';
+            const input: McpToolTriggerOptions = {
+                toolName: 'schema-tool',
+                description: 'Schema passthrough',
+                toolProperties: [],
+                resultSchema,
+            };
+
+            const result = converToMcpToolTriggerOptionsToRpc(input);
+            expect(result.useResultSchema).to.equal(true);
+            expect(result.resultSchema).to.equal(resultSchema);
+        });
+
+        it('throws for invalid resultSchema JSON', () => {
+            const input: McpToolTriggerOptions = {
+                toolName: 'invalid-schema-tool',
+                description: 'Schema validation',
+                toolProperties: [],
+                resultSchema: '{invalid json}',
+            };
+
+            expect(() => converToMcpToolTriggerOptionsToRpc(input)).to.throw(
+                'MCP Tool trigger "resultSchema" must be a valid JSON string.'
+            );
+        });
+    });
 });

--- a/test/mcpContentMarker.test.ts
+++ b/test/mcpContentMarker.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { McpContent } from '../src';
+import { hasMcpContentMarker, shouldCreateStructuredContentMarker } from '../src/utils/mcpContentMarker';
+
+describe('McpContent marker', () => {
+    it('marks a class when called directly', () => {
+        class DirectMarkedType {}
+
+        McpContent(DirectMarkedType);
+
+        expect(hasMcpContentMarker(DirectMarkedType)).to.equal(true);
+        expect(hasMcpContentMarker(new DirectMarkedType())).to.equal(true);
+        expect(shouldCreateStructuredContentMarker(new DirectMarkedType())).to.equal(true);
+    });
+
+    it('marks a class when called with no args (decorator factory form)', () => {
+        class FactoryMarkedType {}
+
+        const applyDecorator = McpContent();
+        applyDecorator(FactoryMarkedType);
+
+        expect(hasMcpContentMarker(FactoryMarkedType)).to.equal(true);
+        expect(hasMcpContentMarker(new FactoryMarkedType())).to.equal(true);
+        expect(shouldCreateStructuredContentMarker(new FactoryMarkedType())).to.equal(true);
+    });
+
+    it('does not mark unannotated values', () => {
+        class UnmarkedType {}
+
+        expect(hasMcpContentMarker(UnmarkedType)).to.equal(false);
+        expect(hasMcpContentMarker(new UnmarkedType())).to.equal(false);
+        expect(shouldCreateStructuredContentMarker(new UnmarkedType())).to.equal(false);
+        expect(shouldCreateStructuredContentMarker({ foo: 'bar' })).to.equal(false);
+        expect(shouldCreateStructuredContentMarker(['x'])).to.equal(false);
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,7 @@ export * from './hooks/logHooks';
 export * from './http';
 export * as input from './input';
 export * from './InvocationContext';
+export { hasMcpContentMarker, McpContent, shouldCreateStructuredContentMarker } from './mcpContentMarker';
 export * from './mcpResource';
 export * from './mcpTool';
 export * from './mySql';

--- a/types/mcpContentMarker.d.ts
+++ b/types/mcpContentMarker.d.ts
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Marks a class or constructor function as an MCP result type that should be serialized
+ * as structured content.
+ *
+ * When a function returns an instance of a type decorated with this marker,
+ * the result will be serialized as both text content (for backwards compatibility)
+ * and structured content (for clients that support it).
+ *
+ * Without the marker, a plain object is serialized as text-only (JSON stringified).
+ * Use `CallToolResult` if you need explicit control over structuredContent without a class.
+ *
+ * **Programmatic usage** (works without `experimentalDecorators`):
+ * ```typescript
+ * class ImageMetadata {
+ *   constructor(public imageId: string, public format: string) {}
+ * }
+ * McpContent(ImageMetadata);  // marks the class
+ *
+ * app.mcpTool('GetImage', {
+ *   toolName: 'GetImage',
+ *   description: 'Returns image info',
+ *   handler: async () => new ImageMetadata('logo', 'png')
+ * });
+ * ```
+ *
+ * **Decorator usage** (requires `experimentalDecorators: true` in tsconfig):
+ * ```typescript
+ * @McpContent
+ * class ImageMetadata { ... }
+ * ```
+ *
+ * Supported forms:
+ * - `@McpContent`
+ * - `@McpContent()`
+ * - `McpContent(MyClass)`
+ *
+ * @param target - Optional class or constructor function to mark for structured content.
+ * @returns The target class/function unchanged or a class decorator.
+ *
+ * @see {@link CallToolResult} - For explicit content blocks + structuredContent
+ * @see {@link ImageContentBlock | TextContentBlock} - For returning single content blocks
+ */
+export function McpContent<T extends { new (...args: any[]): unknown }>(target: T): T;
+export function McpContent(): <T extends { new (...args: any[]): unknown }>(target: T) => T;
+
+/**
+ * Checks if an object's type/class is marked with the @McpContent decorator.
+ *
+ * @param obj - The object or class constructor to check.
+ * @returns True if the class was marked with `McpContent`; otherwise, false.
+ * @internal
+ */
+export function hasMcpContentMarker(obj: unknown): boolean;
+
+/**
+ * Returns true only when `obj` is an instance of a class explicitly marked with
+ * `McpContent` and is not a primitive, array, or built-in type.
+ *
+ * This follows the marker/decorator pattern used by MCP SDKs:
+ * - Marked class instances   → true  → text + structuredContent emitted
+ * - Plain objects / literals → false → text only
+ *
+ * @param obj - The value to evaluate.
+ * @returns True if structured content should be emitted for this value.
+ * @internal
+ */
+export function shouldCreateStructuredContentMarker(obj: unknown): boolean;

--- a/types/mcpTool.d.ts
+++ b/types/mcpTool.d.ts
@@ -57,6 +57,14 @@ export interface McpToolTriggerOptions {
      * Additional metadata about the tool in JSON format.
      */
     metadata?: string;
+
+    /**
+     * Optional JSON-serialized JSON Schema describing the structured result of this tool.
+     *
+     * When provided, the value is validated as JSON and sent alongside `useResultSchema: true`
+     * so MCP clients that support structured content can use the declared schema.
+     */
+    resultSchema?: string;
 }
 
 /**
@@ -77,6 +85,11 @@ export interface McpToolTriggerOptionsToRpc {
     description: string;
 
     /**
+     * Always enabled so the host contract advertises structured-result support.
+     */
+    useResultSchema: boolean;
+
+    /**
      * Additional properties or metadata for the tool.
      * This is a dictionary of key-value pairs that can be used to configure the trigger.
      */
@@ -87,6 +100,11 @@ export interface McpToolTriggerOptionsToRpc {
      * Additional metadata about the tool in JSON format.
      */
     metadata?: string;
+
+    /**
+     * Optional JSON-serialized JSON Schema describing the structured result of this tool.
+     */
+    resultSchema?: string;
 }
 
 /**
@@ -132,3 +150,86 @@ export type Arg = Omit<McpToolProperty, 'propertyName'>;
  * Tool properties format - an object mapping property names to their definitions
  */
 export type Args = Record<string, Arg>;
+
+/**
+ * A text content block in an MCP tool response.
+ * Equivalent to .NET's TextContentBlock.
+ */
+export interface TextContentBlock {
+    type: 'text';
+    text: string;
+}
+
+/**
+ * An image content block in an MCP tool response.
+ * Equivalent to .NET's ImageContentBlock.
+ * `data` must be base64-encoded. The library automatically encodes Buffer/ArrayBuffer values.
+ */
+export interface ImageContentBlock {
+    type: 'image';
+    data: string | Buffer | ArrayBuffer;
+    mimeType?: string;
+}
+
+/**
+ * An audio content block in an MCP tool response.
+ */
+export interface AudioContentBlock {
+    type: 'audio';
+    data: string | Buffer | ArrayBuffer;
+    mimeType?: string;
+}
+
+/**
+ * A resource-link content block in an MCP tool response.
+ */
+export interface ResourceLinkContentBlock {
+    type: 'resource_link';
+    uri: string;
+    name?: string;
+    description?: string;
+    mimeType?: string;
+}
+
+/**
+ * Union of all known content block types for an MCP tool response.
+ * Equivalent to .NET's ContentBlock base class.
+ */
+export type McpContentBlock =
+    | TextContentBlock
+    | ImageContentBlock
+    | AudioContentBlock
+    | ResourceLinkContentBlock
+    | Record<string, unknown>;
+
+/**
+ * Full call-tool result with explicit content blocks and optional structured content.
+ * Use this when you need manual control over both content and structuredContent.
+ * Equivalent to constructing a CallToolResult in .NET with explicit blocks.
+ *
+ * ```typescript
+ * return {
+ *   content: [
+ *     { type: 'text', text: 'Here is the image' },
+ *     { type: 'image', data: base64Data, mimeType: 'image/png' }
+ *   ],
+ *   structuredContent: { imageId: 'logo', format: 'png' }
+ * };
+ * ```
+ */
+export interface CallToolResult {
+    content: McpContentBlock[];
+    structuredContent?: unknown;
+    isError?: boolean;
+}
+
+/**
+ * Internal wire payload emitted by the library after converting a tool's return value.
+ * Customers do not construct this directly — return one of the above types instead.
+ * @internal
+ */
+export interface McpToolResult {
+    type: string;
+    content?: string;
+    structuredContent?: string;
+}


### PR DESCRIPTION
https://github.com/Azure/azure-functions-nodejs-worker/issues/785


Adds structured content support for MCP Tool triggers.

Functions can now return typed content blocks (TextContentBlock, ImageContentBlock, AudioContentBlock, ResourceLinkContentBlock, CallToolResult) or use the new @McpContent class decorator to automatically emit both text and structuredContent from plain class instances.

Binary payloads in image/audio blocks are auto-encoded to base64. 

The host contract now always advertises useResultSchema: true, with optional resultSchema JSON Schema passthrough. Includes full unit test coverage across the conversion pipeline, marker utility, trigger contract, and InvocationModel serialization path (56 tests passing).