### PR TITLE
Updating the Package Version for MCP Structured Content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.12.0",
+    "version": "4.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.12.0",
+            "version": "4.13.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.12.0",
+    "version": "4.13.0",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.12.0';
+export const version = '4.13.0';
 
 export const returnBindingKey = '$return';


### PR DESCRIPTION
PR updates the MCP Structured Content package version from 4.12.0 to 4.13.0 to keep versioning aligned across package metadata and runtime constants.