### PR TITLE
Replace structural MCP tool-result detection with class-based API

### DIFF
--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -120,7 +120,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
             if (binding.direction === 'out') {
                 if (name === returnBindingKey) {
                     response.returnValue = isMcpToolTrigger(this.#triggerType)
-                        ? this.#convertMcpToolReturnValue(result)
+                        ? this.#convertMcpToolReturnValue(context, result)
                         : await this.#convertOutput(context.invocationId, binding, result);
                     usedReturnValue = true;
                 } else {
@@ -141,7 +141,7 @@ export class InvocationModel implements coreTypes.InvocationModel {
         // but e.g., Durable uses this to pass orchestrator state back to the Durable extension, w/o
         // an explicit output binding. See here for more details: https://github.com/Azure/azure-functions-nodejs-library/pull/25
         if (!usedReturnValue && !isHttpTrigger(this.#triggerType)) {
-            response.returnValue = this.#convertMcpToolReturnValue(result);
+            response.returnValue = this.#convertMcpToolReturnValue(context, result);
         }
 
         return response;
@@ -159,12 +159,12 @@ export class InvocationModel implements coreTypes.InvocationModel {
         }
     }
 
-    #convertMcpToolReturnValue(value: unknown): RpcTypedData | null | undefined {
+    #convertMcpToolReturnValue(context: InvocationContext, value: unknown): RpcTypedData | null | undefined {
         if (!isMcpToolTrigger(this.#triggerType)) {
             return toRpcTypedData(value);
         }
 
-        const converted = toMcpToolResult(value);
+        const converted = toMcpToolResult(value, context);
 
         if (converted === null || converted === undefined) {
             return converted;

--- a/src/converters/toMcpToolResult.ts
+++ b/src/converters/toMcpToolResult.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import type { McpToolResult } from '@azure/functions';
-import { McpContentBlock, McpToolResponse, TextContent } from '../mcp/McpToolResponse';
+import { McpContentBlock, McpTextContent, McpToolResponse } from '../mcp/McpToolResponse';
 import { warnIfLooksLikeMcpSdkValue } from '../mcp/sdkCompat';
 import { shouldCreateStructuredContentMarker } from '../utils/mcpContentMarker';
 
@@ -85,14 +85,14 @@ function serializeToolResponse(response: McpToolResponse): McpToolResult {
 
 /**
  * Some MCP clients require a text content block alongside structured content for display.
- * If the response declares `structuredContent` but has no `TextContent` block, synthesize one.
+ * If the response declares `structuredContent` but has no `McpTextContent` block, synthesize one.
  */
 function ensureTextBlockWhenStructured(response: McpToolResponse): McpContentBlock[] {
     if (response.structuredContent === null || response.structuredContent === undefined) {
         return response.content;
     }
 
-    if (response.content.some((b) => b instanceof TextContent)) {
+    if (response.content.some((b) => b instanceof McpTextContent)) {
         return response.content;
     }
 
@@ -101,5 +101,5 @@ function ensureTextBlockWhenStructured(response: McpToolResponse): McpContentBlo
             ? response.structuredContent
             : JSON.stringify(response.structuredContent);
 
-    return [...response.content, new TextContent(fallbackText)];
+    return [...response.content, new McpTextContent(fallbackText)];
 }

--- a/src/converters/toMcpToolResult.ts
+++ b/src/converters/toMcpToolResult.ts
@@ -2,61 +2,47 @@
 // Licensed under the MIT License.
 
 import type { McpToolResult } from '@azure/functions';
+import { McpContentBlock, McpToolResponse, TextContent } from '../mcp/McpToolResponse';
 import { shouldCreateStructuredContentMarker } from '../utils/mcpContentMarker';
-
-interface TextContentBlock {
-    type: 'text';
-    text: string;
-}
 
 const multiContentResultType = 'multi_content_result';
 const textContentResultType = 'text';
-const directContentBlockTypes = new Set(['text', 'image', 'audio', 'resource', 'resource_link']);
-
-interface CallToolResultLike {
-    content: unknown[];
-    structuredContent?: unknown;
-}
 
 /**
- * Converts a tool return value into a normalized MCP tool result.
+ * Converts a tool handler's return value into the wire-format MCP tool result.
  *
- * Supported inputs include CallToolResult-like objects, direct content blocks,
- * arrays of content blocks, existing MCP results, and plain values.
+ * Accepted inputs:
+ *  - `null` / `undefined` → passed through.
+ *  - `McpToolResponse` instance → serialized as-is.
+ *  - `McpContentBlock` instance → wrapped in a single-block response.
+ *  - Non-empty array of `McpContentBlock` instances → wrapped in a multi-block response.
+ *  - Any other value → serialized as a text block. If the value's class is marked with
+ *    `@McpContent`, it is also emitted as `structuredContent`.
+ *
+ * Detection uses `instanceof` exclusively — arbitrary user objects that happen to have a
+ * `content`/`type`/`structuredContent` field are treated as plain values.
  */
 export function toMcpToolResult(result: unknown): McpToolResult | null | undefined {
     if (result === null || result === undefined) {
         return result;
     }
 
-    if (isCallToolResult(result)) {
-        const callToolResult = ensureCallToolResultHasTextContent(result);
-        const normalizedBlocks = normalizeContentBlocks(callToolResult.content);
-        const mcpResult = createMcpToolResultFromContentBlocks(normalizedBlocks);
-        mcpResult.structuredContent = serializeStructuredContent(callToolResult.structuredContent);
-        return mcpResult;
+    if (result instanceof McpToolResponse) {
+        return serializeToolResponse(result);
     }
 
-    if (isContentBlockArray(result)) {
-        const normalizedBlocks = normalizeContentBlocks(result);
-        const mcpResult = createMcpToolResultFromContentBlocks(normalizedBlocks);
-        return mcpResult;
+    if (result instanceof McpContentBlock) {
+        return serializeToolResponse(new McpToolResponse({ content: [result] }));
     }
 
-    if (isContentBlock(result)) {
-        const normalizedBlock = normalizeContentBlock(result);
-        const mcpResult = createMcpToolResultFromContentBlocks([normalizedBlock]);
-        return mcpResult;
-    }
-
-    if (isMcpToolResult(result)) {
-        return normalizeMcpToolResult(result);
+    if (Array.isArray(result) && result.length > 0 && result.every((b) => b instanceof McpContentBlock)) {
+        return serializeToolResponse(new McpToolResponse({ content: result as McpContentBlock[] }));
     }
 
     const text = typeof result === 'string' ? result : JSON.stringify(result);
     const mcpResult: McpToolResult = {
         type: textContentResultType,
-        content: JSON.stringify({ type: textContentResultType, text } as TextContentBlock),
+        content: JSON.stringify({ type: textContentResultType, text }),
     };
 
     if (shouldCreateStructuredContentMarker(result)) {
@@ -66,196 +52,49 @@ export function toMcpToolResult(result: unknown): McpToolResult | null | undefin
     return mcpResult;
 }
 
-/**
- * Creates an MCP tool result from one or many normalized content blocks.
- * A single block preserves its own type; multiple blocks become multi_content_result.
- */
-function createMcpToolResultFromContentBlocks(content: unknown[]): McpToolResult {
-    if (content.length === 1) {
-        const [block] = content;
-        const blockType = getContentBlockType(block);
-        return {
-            type: blockType,
-            content: JSON.stringify(block),
-        };
+function serializeToolResponse(response: McpToolResponse): McpToolResult {
+    const blocks = ensureTextBlockWhenStructured(response);
+
+    let type: string;
+    let contentStr: string;
+    if (blocks.length === 1) {
+        const [block] = blocks as [McpContentBlock];
+        type = block.type;
+        contentStr = JSON.stringify(block);
+    } else {
+        type = multiContentResultType;
+        contentStr = JSON.stringify(blocks);
     }
 
-    return {
-        type: multiContentResultType,
-        content: JSON.stringify(content),
-    };
-}
+    const out: McpToolResult = { type, content: contentStr };
 
-/**
- * Normalizes all blocks in a content array.
- */
-function normalizeContentBlocks(content: unknown[]): unknown[] {
-    return content.map((block) => normalizeContentBlock(block));
-}
-
-/**
- * Normalizes one content block and base64-encodes binary payloads for image/audio.
- */
-function normalizeContentBlock(block: unknown): unknown {
-    if (!block || typeof block !== 'object') {
-        return block;
+    if (response.structuredContent !== undefined && response.structuredContent !== null) {
+        out.structuredContent =
+            typeof response.structuredContent === 'string'
+                ? response.structuredContent
+                : JSON.stringify(response.structuredContent);
     }
 
-    const contentBlock = { ...(block as Record<string, unknown>) };
-    const type = getContentBlockType(contentBlock);
+    return out;
+}
 
-    if ((type === 'image' || type === 'audio') && 'data' in contentBlock) {
-        contentBlock.data = normalizeBinaryData(contentBlock.data);
+/**
+ * Some MCP clients require a text content block alongside structured content for display.
+ * If the response declares `structuredContent` but has no `TextContent` block, synthesize one.
+ */
+function ensureTextBlockWhenStructured(response: McpToolResponse): McpContentBlock[] {
+    if (response.structuredContent === null || response.structuredContent === undefined) {
+        return response.content;
     }
 
-    return contentBlock;
-}
-
-/**
- * Converts binary-like values into base64 strings when possible.
- */
-function normalizeBinaryData(data: unknown): unknown {
-    if (typeof data === 'string' || data === null || data === undefined) {
-        return data;
-    }
-
-    if (Buffer.isBuffer(data)) {
-        return data.toString('base64');
-    }
-
-    if (ArrayBuffer.isView(data)) {
-        const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-        return Buffer.from(view).toString('base64');
-    }
-
-    if (data instanceof ArrayBuffer) {
-        return Buffer.from(new Uint8Array(data)).toString('base64');
-    }
-
-    return data;
-}
-
-/**
- * Checks whether a value already looks like an MCP tool result payload.
- */
-function isMcpToolResult(value: unknown): value is McpToolResult {
-    return (
-        !!value &&
-        typeof value === 'object' &&
-        typeof (value as McpToolResult).type === 'string' &&
-        ('content' in (value as Record<string, unknown>) || 'structuredContent' in (value as Record<string, unknown>))
-    );
-}
-
-/**
- * Checks whether a value is a single direct content block.
- */
-function isContentBlock(value: unknown): value is Record<string, unknown> & { type: string } {
-    return (
-        !!value &&
-        typeof value === 'object' &&
-        typeof (value as { type?: unknown }).type === 'string' &&
-        !('content' in (value as Record<string, unknown>)) &&
-        directContentBlockTypes.has((value as { type: string }).type)
-    );
-}
-
-/**
- * Checks whether a value is a non-empty array of direct content blocks.
- */
-function isContentBlockArray(value: unknown): value is Array<Record<string, unknown> & { type: string }> {
-    return Array.isArray(value) && value.length > 0 && value.every((item) => isContentBlock(item));
-}
-
-/**
- * Normalizes an existing MCP tool result by serializing non-string fields.
- */
-function normalizeMcpToolResult(result: McpToolResult): McpToolResult {
-    return {
-        ...result,
-        content: serializeOptionalContent(result.content),
-        structuredContent: serializeStructuredContent(result.structuredContent),
-    };
-}
-
-/**
- * Serializes optional content when present and non-string.
- */
-function serializeOptionalContent(content: unknown): string | undefined {
-    if (content === null || content === undefined) {
-        return undefined;
-    }
-
-    if (typeof content === 'string') {
-        return content;
-    }
-
-    return JSON.stringify(content);
-}
-
-/**
- * Checks whether a value matches the minimal CallToolResult shape.
- */
-function isCallToolResult(value: unknown): value is CallToolResultLike {
-    return !!value && typeof value === 'object' && Array.isArray((value as { content?: unknown }).content);
-}
-
-/**
- * Ensures CallToolResult content includes a text block when structuredContent exists.
- *
- * Some MCP clients require text in addition to structured content for display.
- */
-function ensureCallToolResultHasTextContent(result: CallToolResultLike): CallToolResultLike {
-    if (
-        result.structuredContent === null ||
-        result.structuredContent === undefined ||
-        hasTextContentBlock(result.content)
-    ) {
-        return result;
+    if (response.content.some((b) => b instanceof TextContent)) {
+        return response.content;
     }
 
     const fallbackText =
-        typeof result.structuredContent === 'string'
-            ? result.structuredContent
-            : JSON.stringify(result.structuredContent);
+        typeof response.structuredContent === 'string'
+            ? response.structuredContent
+            : JSON.stringify(response.structuredContent);
 
-    return {
-        ...result,
-        content: [...result.content, { type: textContentResultType, text: fallbackText }],
-    };
-}
-
-/**
- * Returns a content block type, defaulting to text for malformed blocks.
- */
-function getContentBlockType(block: unknown): string {
-    if (block && typeof block === 'object' && typeof (block as { type?: unknown }).type === 'string') {
-        return (block as { type: string }).type;
-    }
-
-    return textContentResultType;
-}
-
-/**
- * Returns true when at least one content block is a text block.
- */
-function hasTextContentBlock(content: unknown[]): boolean {
-    return content.some((block) => {
-        return !!block && typeof block === 'object' && (block as { type?: unknown }).type === textContentResultType;
-    });
-}
-
-/**
- * Serializes structured content when present and non-string.
- */
-function serializeStructuredContent(content: unknown): string | undefined {
-    if (content === null || content === undefined) {
-        return undefined;
-    }
-
-    if (typeof content === 'string') {
-        return content;
-    }
-
-    return JSON.stringify(content);
+    return [...response.content, new TextContent(fallbackText)];
 }

--- a/src/converters/toMcpToolResult.ts
+++ b/src/converters/toMcpToolResult.ts
@@ -3,6 +3,7 @@
 
 import type { McpToolResult } from '@azure/functions';
 import { McpContentBlock, McpToolResponse, TextContent } from '../mcp/McpToolResponse';
+import { warnIfLooksLikeMcpSdkValue } from '../mcp/sdkCompat';
 import { shouldCreateStructuredContentMarker } from '../utils/mcpContentMarker';
 
 const multiContentResultType = 'multi_content_result';
@@ -38,6 +39,10 @@ export function toMcpToolResult(result: unknown): McpToolResult | null | undefin
     if (Array.isArray(result) && result.length > 0 && result.every((b) => b instanceof McpContentBlock)) {
         return serializeToolResponse(new McpToolResponse({ content: result as McpContentBlock[] }));
     }
+
+    // Plain-value path: warn once if the value looks like an MCP SDK shape that
+    // the user likely intended to be converted. Behavior is unchanged.
+    warnIfLooksLikeMcpSdkValue(result);
 
     const text = typeof result === 'string' ? result : JSON.stringify(result);
     const mcpResult: McpToolResult = {

--- a/src/converters/toMcpToolResult.ts
+++ b/src/converters/toMcpToolResult.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import type { McpToolResult } from '@azure/functions';
+import type { InvocationContext, McpToolResult } from '@azure/functions';
 import { McpContentBlock, McpTextContent, McpToolResponse } from '../mcp/McpToolResponse';
 import { warnIfLooksLikeMcpSdkValue } from '../mcp/sdkCompat';
 import { shouldCreateStructuredContentMarker } from '../utils/mcpContentMarker';
@@ -22,8 +22,11 @@ const textContentResultType = 'text';
  *
  * Detection uses `instanceof` exclusively — arbitrary user objects that happen to have a
  * `content`/`type`/`structuredContent` field are treated as plain values.
+ *
+ * @param context Optional `InvocationContext` used to surface a one-time warning when the
+ *   value looks like an `@modelcontextprotocol/sdk` response that is not auto-converted.
  */
-export function toMcpToolResult(result: unknown): McpToolResult | null | undefined {
+export function toMcpToolResult(result: unknown, context?: InvocationContext): McpToolResult | null | undefined {
     if (result === null || result === undefined) {
         return result;
     }
@@ -42,7 +45,7 @@ export function toMcpToolResult(result: unknown): McpToolResult | null | undefin
 
     // Plain-value path: warn once if the value looks like an MCP SDK shape that
     // the user likely intended to be converted. Behavior is unchanged.
-    warnIfLooksLikeMcpSdkValue(result);
+    warnIfLooksLikeMcpSdkValue(result, context);
 
     const text = typeof result === 'string' ? result : JSON.stringify(result);
     const mcpResult: McpToolResult = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,15 @@ export { HttpRequest } from './http/HttpRequest';
 export { HttpResponse } from './http/HttpResponse';
 export * as input from './input';
 export { InvocationContext } from './InvocationContext';
+export {
+    AudioContent,
+    ImageContent,
+    McpContentBlock,
+    McpToolResponse,
+    ResourceContent,
+    ResourceLinkContent,
+    TextContent,
+} from './mcp/McpToolResponse';
 export * as output from './output';
 export * as trigger from './trigger';
 export { Disposable } from './utils/Disposable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ export { HttpResponse } from './http/HttpResponse';
 export * as input from './input';
 export { InvocationContext } from './InvocationContext';
 export {
-    AudioContent,
-    ImageContent,
+    McpAudioContent,
     McpContentBlock,
+    McpImageContent,
+    McpResourceContent,
+    McpResourceLinkContent,
+    McpTextContent,
     McpToolResponse,
-    ResourceContent,
-    ResourceLinkContent,
-    TextContent,
 } from './mcp/McpToolResponse';
 export * as output from './output';
 export * as trigger from './trigger';

--- a/src/mcp/McpToolResponse.ts
+++ b/src/mcp/McpToolResponse.ts
@@ -29,6 +29,90 @@ function normalizeBinaryData(data: BinaryData): string {
  * Base class for all MCP content blocks. The library uses `instanceof McpContentBlock`
  * to discriminate content blocks from plain user values, so every content-block subclass
  * must extend this class.
+ *
+ * ## Extending with custom content block types
+ *
+ * The library ships built-in subclasses for the MCP spec's current content block types
+ * (`TextContent`, `ImageContent`, `AudioContent`, `ResourceLinkContent`, `ResourceContent`).
+ * If the spec adds a new block type — or your scenario needs a custom one — you can ship
+ * your own subclass without any library change. The converter only checks
+ * `instanceof McpContentBlock` and calls `JSON.stringify(block)`, which invokes your
+ * `toJSON()` to produce the wire payload.
+ *
+ * ### Example: adding a hypothetical `VideoContent`
+ *
+ * ```ts
+ * import { McpContentBlock } from '@azure/functions';
+ *
+ * export interface VideoContentInit {
+ *     data: string | Buffer | ArrayBuffer;
+ *     mimeType: string;          // e.g. 'video/mp4'
+ *     durationMs?: number;       // optional field from a hypothetical spec
+ * }
+ *
+ * export class VideoContent extends McpContentBlock {
+ *     readonly type = 'video' as const;
+ *     readonly data: string | Buffer | ArrayBuffer;
+ *     readonly mimeType: string;
+ *     readonly durationMs?: number;
+ *
+ *     constructor(init: VideoContentInit) {
+ *         super();
+ *         this.data = init.data;
+ *         this.mimeType = init.mimeType;
+ *         this.durationMs = init.durationMs;
+ *     }
+ *
+ *     toJSON(): Record<string, unknown> {
+ *         const out: Record<string, unknown> = {
+ *             type: this.type,
+ *             data: toBase64(this.data),
+ *             mimeType: this.mimeType,
+ *         };
+ *         if (this.durationMs !== undefined) out.durationMs = this.durationMs;
+ *         return out;
+ *     }
+ * }
+ *
+ * function toBase64(data: string | Buffer | ArrayBuffer): string {
+ *     if (typeof data === 'string') return data;
+ *     if (Buffer.isBuffer(data)) return data.toString('base64');
+ *     return Buffer.from(new Uint8Array(data)).toString('base64');
+ * }
+ * ```
+ *
+ * ### Using a custom block from a tool handler
+ *
+ * Return it standalone, or mix it with built-in blocks inside an `McpToolResponse`:
+ *
+ * ```ts
+ * // Single block
+ * handler: async () => new VideoContent({ data: buf, mimeType: 'video/mp4' })
+ *
+ * // Mixed with built-ins + structured content
+ * handler: async () => new McpToolResponse({
+ *     content: [
+ *         new TextContent('Detected 3 scenes'),
+ *         new VideoContent({ data: buf, mimeType: 'video/mp4' }),
+ *     ],
+ *     structuredContent: { scenes: 3, confidence: 0.92 },
+ * })
+ * ```
+ *
+ * ### What the library does for you
+ *
+ *  - `instanceof McpContentBlock` treats your subclass identically to built-in blocks.
+ *  - Single-block returns propagate your `type` string to the outer result; arrays are
+ *    wrapped as `multi_content_result`.
+ *  - `structuredContent` handling, fallback-text synthesis, and nullish passthrough all
+ *    apply unchanged.
+ *
+ * ### What you must get right in your subclass
+ *
+ *  - `toJSON()` must return the exact wire shape the spec requires for your `type`.
+ *  - Binary payloads should be base64-encoded in `toJSON()` (see the `toBase64` helper
+ *    above).
+ *  - Plain object literals are **not** recognized — you must construct an instance.
  */
 export abstract class McpContentBlock {
     abstract readonly type: string;

--- a/src/mcp/McpToolResponse.ts
+++ b/src/mcp/McpToolResponse.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 import type {
-    AudioContentInit as IAudioContentInit,
-    ImageContentInit as IImageContentInit,
+    McpAudioContentInit as IAudioContentInit,
+    McpImageContentInit as IImageContentInit,
+    McpResourceContentInit as IResourceContentInit,
+    McpResourceLinkContentInit as IResourceLinkContentInit,
     McpToolResponseInit as IMcpToolResponseInit,
-    ResourceContentInit as IResourceContentInit,
-    ResourceLinkContentInit as IResourceLinkContentInit,
 } from '@azure/functions';
 
 type BinaryData = string | Buffer | ArrayBuffer;
@@ -33,7 +33,7 @@ function normalizeBinaryData(data: BinaryData): string {
  * ## Extending with custom content block types
  *
  * The library ships built-in subclasses for the MCP spec's current content block types
- * (`TextContent`, `ImageContent`, `AudioContent`, `ResourceLinkContent`, `ResourceContent`).
+ * (`McpTextContent`, `McpImageContent`, `McpAudioContent`, `McpResourceLinkContent`, `McpResourceContent`).
  * If the spec adds a new block type — or your scenario needs a custom one — you can ship
  * your own subclass without any library change. The converter only checks
  * `instanceof McpContentBlock` and calls `JSON.stringify(block)`, which invokes your
@@ -92,7 +92,7 @@ function normalizeBinaryData(data: BinaryData): string {
  * // Mixed with built-ins + structured content
  * handler: async () => new McpToolResponse({
  *     content: [
- *         new TextContent('Detected 3 scenes'),
+ *         new McpTextContent('Detected 3 scenes'),
  *         new VideoContent({ data: buf, mimeType: 'video/mp4' }),
  *     ],
  *     structuredContent: { scenes: 3, confidence: 0.92 },
@@ -124,7 +124,7 @@ export abstract class McpContentBlock {
     abstract toJSON(): Record<string, unknown>;
 }
 
-export class TextContent extends McpContentBlock {
+export class McpTextContent extends McpContentBlock {
     readonly type = 'text' as const;
     readonly text: string;
 
@@ -138,7 +138,7 @@ export class TextContent extends McpContentBlock {
     }
 }
 
-export class ImageContent extends McpContentBlock {
+export class McpImageContent extends McpContentBlock {
     readonly type = 'image' as const;
     readonly data: BinaryData;
     readonly mimeType?: string;
@@ -161,7 +161,7 @@ export class ImageContent extends McpContentBlock {
     }
 }
 
-export class AudioContent extends McpContentBlock {
+export class McpAudioContent extends McpContentBlock {
     readonly type = 'audio' as const;
     readonly data: BinaryData;
     readonly mimeType?: string;
@@ -184,7 +184,7 @@ export class AudioContent extends McpContentBlock {
     }
 }
 
-export class ResourceLinkContent extends McpContentBlock {
+export class McpResourceLinkContent extends McpContentBlock {
     readonly type = 'resource_link' as const;
     readonly uri: string;
     readonly name?: string;
@@ -208,7 +208,7 @@ export class ResourceLinkContent extends McpContentBlock {
     }
 }
 
-export class ResourceContent extends McpContentBlock {
+export class McpResourceContent extends McpContentBlock {
     readonly type = 'resource' as const;
     readonly resource: IResourceContentInit['resource'];
 

--- a/src/mcp/McpToolResponse.ts
+++ b/src/mcp/McpToolResponse.ts
@@ -1,0 +1,161 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import type {
+    AudioContentInit as IAudioContentInit,
+    ImageContentInit as IImageContentInit,
+    McpToolResponseInit as IMcpToolResponseInit,
+    ResourceContentInit as IResourceContentInit,
+    ResourceLinkContentInit as IResourceLinkContentInit,
+} from '@azure/functions';
+
+type BinaryData = string | Buffer | ArrayBuffer;
+
+function normalizeBinaryData(data: BinaryData): string {
+    if (typeof data === 'string') {
+        return data;
+    }
+    if (Buffer.isBuffer(data)) {
+        return data.toString('base64');
+    }
+    if (ArrayBuffer.isView(data)) {
+        const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        return Buffer.from(view).toString('base64');
+    }
+    return Buffer.from(new Uint8Array(data)).toString('base64');
+}
+
+/**
+ * Base class for all MCP content blocks. The library uses `instanceof McpContentBlock`
+ * to discriminate content blocks from plain user values, so every content-block subclass
+ * must extend this class.
+ */
+export abstract class McpContentBlock {
+    abstract readonly type: string;
+
+    /**
+     * Returns the wire representation of this block. Subclasses override to normalize
+     * binary payloads and omit undefined fields.
+     */
+    abstract toJSON(): Record<string, unknown>;
+}
+
+export class TextContent extends McpContentBlock {
+    readonly type = 'text' as const;
+    readonly text: string;
+
+    constructor(text: string) {
+        super();
+        this.text = text;
+    }
+
+    toJSON(): Record<string, unknown> {
+        return { type: this.type, text: this.text };
+    }
+}
+
+export class ImageContent extends McpContentBlock {
+    readonly type = 'image' as const;
+    readonly data: BinaryData;
+    readonly mimeType?: string;
+
+    constructor(init: IImageContentInit) {
+        super();
+        this.data = init.data;
+        this.mimeType = init.mimeType;
+    }
+
+    toJSON(): Record<string, unknown> {
+        const out: Record<string, unknown> = {
+            type: this.type,
+            data: normalizeBinaryData(this.data),
+        };
+        if (this.mimeType !== undefined) {
+            out.mimeType = this.mimeType;
+        }
+        return out;
+    }
+}
+
+export class AudioContent extends McpContentBlock {
+    readonly type = 'audio' as const;
+    readonly data: BinaryData;
+    readonly mimeType?: string;
+
+    constructor(init: IAudioContentInit) {
+        super();
+        this.data = init.data;
+        this.mimeType = init.mimeType;
+    }
+
+    toJSON(): Record<string, unknown> {
+        const out: Record<string, unknown> = {
+            type: this.type,
+            data: normalizeBinaryData(this.data),
+        };
+        if (this.mimeType !== undefined) {
+            out.mimeType = this.mimeType;
+        }
+        return out;
+    }
+}
+
+export class ResourceLinkContent extends McpContentBlock {
+    readonly type = 'resource_link' as const;
+    readonly uri: string;
+    readonly name?: string;
+    readonly description?: string;
+    readonly mimeType?: string;
+
+    constructor(init: IResourceLinkContentInit) {
+        super();
+        this.uri = init.uri;
+        this.name = init.name;
+        this.description = init.description;
+        this.mimeType = init.mimeType;
+    }
+
+    toJSON(): Record<string, unknown> {
+        const out: Record<string, unknown> = { type: this.type, uri: this.uri };
+        if (this.name !== undefined) out.name = this.name;
+        if (this.description !== undefined) out.description = this.description;
+        if (this.mimeType !== undefined) out.mimeType = this.mimeType;
+        return out;
+    }
+}
+
+export class ResourceContent extends McpContentBlock {
+    readonly type = 'resource' as const;
+    readonly resource: IResourceContentInit['resource'];
+
+    constructor(init: IResourceContentInit) {
+        super();
+        this.resource = init.resource;
+    }
+
+    toJSON(): Record<string, unknown> {
+        const r = this.resource;
+        const inner: Record<string, unknown> = { uri: r.uri };
+        if (r.mimeType !== undefined) inner.mimeType = r.mimeType;
+        if (r.text !== undefined) inner.text = r.text;
+        if (r.blob !== undefined) inner.blob = normalizeBinaryData(r.blob);
+        return { type: this.type, resource: inner };
+    }
+}
+
+/**
+ * A complete MCP tool response with explicit content blocks and optional structured content.
+ * Return an instance of this class from a tool handler when you need full control over
+ * both the content array and `structuredContent`.
+ */
+export class McpToolResponse {
+    readonly content: McpContentBlock[];
+    readonly structuredContent?: unknown;
+    readonly isError?: boolean;
+
+    constructor(init: IMcpToolResponseInit) {
+        this.content = init.content;
+        this.structuredContent = init.structuredContent;
+        this.isError = init.isError;
+    }
+}

--- a/src/mcp/sdkCompat.ts
+++ b/src/mcp/sdkCompat.ts
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Heuristically detects values that look like responses from `@modelcontextprotocol/sdk`
+ * (e.g. `CallToolResult` or a raw content block) so we can warn users that those shapes
+ * are not auto-converted. Detection is intentionally broad — false positives only cost
+ * a one-time log line, never a behavior change.
+ */
+export function looksLikeMcpSdkValue(value: unknown): boolean {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+
+    // CallToolResult-like: has a content array.
+    if (Array.isArray(obj.content)) {
+        return true;
+    }
+
+    // Content-block-like: has { type: string } plus a known block field.
+    if (typeof obj.type === 'string') {
+        return 'text' in obj || 'data' in obj || 'uri' in obj || 'resource' in obj;
+    }
+
+    return false;
+}
+
+let warned = false;
+
+/**
+ * Logs a one-time warning when a tool handler returns a value that looks like an
+ * `@modelcontextprotocol/sdk` response. Behavior is unchanged — the value still falls
+ * through to the plain-text path — but the warning steers users to the supported API.
+ *
+ * Idempotent: subsequent calls are no-ops to avoid log spam.
+ */
+export function warnIfLooksLikeMcpSdkValue(value: unknown): void {
+    if (warned || !looksLikeMcpSdkValue(value)) {
+        return;
+    }
+    warned = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+        '[@azure/functions] Tool handler return value looks like an @modelcontextprotocol/sdk response. ' +
+            'Raw SDK shapes are not auto-converted and will be serialized as plain text. ' +
+            'Wrap the return value with `McpToolResponse`/`TextContent`/`ImageContent`/etc. ' +
+            'from `@azure/functions`. ' +
+            'To support a custom content block type, subclass `McpContentBlock` \u2014 ' +
+            'see the `McpContentBlock` JSDoc for a full example.'
+    );
+}
+
+/**
+ * Test-only: reset the one-time warning flag so each test starts from a clean state.
+ * @internal
+ */
+export function __resetMcpSdkWarning(): void {
+    warned = false;
+}

--- a/src/mcp/sdkCompat.ts
+++ b/src/mcp/sdkCompat.ts
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import type { InvocationContext } from '@azure/functions';
+
 /**
  * Heuristically detects values that look like responses from `@modelcontextprotocol/sdk`
  * (e.g. `CallToolResult` or a raw content block) so we can warn users that those shapes
@@ -34,15 +36,18 @@ let warned = false;
  * `@modelcontextprotocol/sdk` response. Behavior is unchanged — the value still falls
  * through to the plain-text path — but the warning steers users to the supported API.
  *
+ * Routed through the invocation's `InvocationContext` so the warning surfaces to the
+ * customer via the Functions host logging pipeline. If no context is supplied, the
+ * warning is skipped.
+ *
  * Idempotent: subsequent calls are no-ops to avoid log spam.
  */
-export function warnIfLooksLikeMcpSdkValue(value: unknown): void {
-    if (warned || !looksLikeMcpSdkValue(value)) {
+export function warnIfLooksLikeMcpSdkValue(value: unknown, context: InvocationContext | undefined): void {
+    if (warned || !context || !looksLikeMcpSdkValue(value)) {
         return;
     }
     warned = true;
-    // eslint-disable-next-line no-console
-    console.warn(
+    context.warn(
         '[@azure/functions] Tool handler return value appears to use types from ' +
             '`@modelcontextprotocol/sdk` (e.g. `CallToolResult`, `TextContent`, `ImageContent`). ' +
             'These types are not supported directly and will be serialized as plain text. ' +

--- a/src/mcp/sdkCompat.ts
+++ b/src/mcp/sdkCompat.ts
@@ -45,7 +45,7 @@ export function warnIfLooksLikeMcpSdkValue(value: unknown): void {
     console.warn(
         '[@azure/functions] Tool handler return value looks like an @modelcontextprotocol/sdk response. ' +
             'Raw SDK shapes are not auto-converted and will be serialized as plain text. ' +
-            'Wrap the return value with `McpToolResponse`/`TextContent`/`ImageContent`/etc. ' +
+            'Wrap the return value with `McpToolResponse`/`McpTextContent`/`McpImageContent`/etc. ' +
             'from `@azure/functions`. ' +
             'To support a custom content block type, subclass `McpContentBlock` \u2014 ' +
             'see the `McpContentBlock` JSDoc for a full example.'

--- a/src/mcp/sdkCompat.ts
+++ b/src/mcp/sdkCompat.ts
@@ -43,12 +43,12 @@ export function warnIfLooksLikeMcpSdkValue(value: unknown): void {
     warned = true;
     // eslint-disable-next-line no-console
     console.warn(
-        '[@azure/functions] Tool handler return value looks like an @modelcontextprotocol/sdk response. ' +
-            'Raw SDK shapes are not auto-converted and will be serialized as plain text. ' +
-            'Wrap the return value with `McpToolResponse`/`McpTextContent`/`McpImageContent`/etc. ' +
-            'from `@azure/functions`. ' +
-            'To support a custom content block type, subclass `McpContentBlock` \u2014 ' +
-            'see the `McpContentBlock` JSDoc for a full example.'
+        '[@azure/functions] Tool handler return value appears to use types from ' +
+            '`@modelcontextprotocol/sdk` (e.g. `CallToolResult`, `TextContent`, `ImageContent`). ' +
+            'These types are not supported directly and will be serialized as plain text. ' +
+            'Use the equivalent classes from `@azure/functions` instead — ' +
+            '`McpToolResponse`, `McpTextContent`, `McpImageContent`, etc. ' +
+            'See the `McpContentBlock` JSDoc for custom content block examples.'
     );
 }
 

--- a/test/InvocationModel.test.ts
+++ b/test/InvocationModel.test.ts
@@ -4,7 +4,7 @@
 import 'mocha';
 import { RpcLogCategory, RpcLogLevel } from '@azure/functions-core';
 import { expect } from 'chai';
-import { ImageContent, InvocationContext, McpContent } from '../src';
+import { McpImageContent, InvocationContext, McpContent } from '../src';
 import { InvocationModel } from '../src/InvocationModel';
 
 function testLog(_level: RpcLogLevel, _category: RpcLogCategory, message: string) {
@@ -141,7 +141,7 @@ describe('InvocationModel', () => {
             const context = new InvocationContext();
             const response = await model.getResponse(
                 context,
-                new ImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' })
+                new McpImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' })
             );
 
             expect(response.invocationId).to.equal('mcpInvocId');

--- a/test/InvocationModel.test.ts
+++ b/test/InvocationModel.test.ts
@@ -4,7 +4,7 @@
 import 'mocha';
 import { RpcLogCategory, RpcLogLevel } from '@azure/functions-core';
 import { expect } from 'chai';
-import { InvocationContext, McpContent } from '../src';
+import { ImageContent, InvocationContext, McpContent } from '../src';
 import { InvocationModel } from '../src/InvocationModel';
 
 function testLog(_level: RpcLogLevel, _category: RpcLogCategory, message: string) {
@@ -139,11 +139,10 @@ describe('InvocationModel', () => {
             });
 
             const context = new InvocationContext();
-            const response = await model.getResponse(context, {
-                type: 'image',
-                data: 'YmFzZTY0',
-                mimeType: 'image/png',
-            });
+            const response = await model.getResponse(
+                context,
+                new ImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' })
+            );
 
             expect(response.invocationId).to.equal('mcpInvocId');
             expect(response.outputData).to.deep.equal([]);

--- a/test/converters/toMcpToolResult.test.ts
+++ b/test/converters/toMcpToolResult.test.ts
@@ -5,13 +5,13 @@ import 'mocha';
 import { expect } from 'chai';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
 import {
-    AudioContent,
-    ImageContent,
+    McpAudioContent,
+    McpImageContent,
     McpContentBlock,
     McpToolResponse,
-    ResourceContent,
-    ResourceLinkContent,
-    TextContent,
+    McpResourceContent,
+    McpResourceLinkContent,
+    McpTextContent,
 } from '../../src/mcp/McpToolResponse';
 import { McpContent } from '../../src/utils/mcpContentMarker';
 
@@ -66,30 +66,30 @@ describe('toMcpToolResult', () => {
         expect(JSON.parse(content.text)).to.deep.equal({ type: 'report', content: 'quarterly results' });
     });
 
-    it('serializes a single TextContent block', () => {
-        const result = toMcpToolResult(new TextContent('hi there'));
+    it('serializes a single McpTextContent block', () => {
+        const result = toMcpToolResult(new McpTextContent('hi there'));
         expect(result?.type).to.equal('text');
         expect(JSON.parse(result?.content || '{}')).to.deep.equal({ type: 'text', text: 'hi there' });
     });
 
-    it('serializes an ImageContent block and normalizes Buffer data to base64', () => {
+    it('serializes an McpImageContent block and normalizes Buffer data to base64', () => {
         const buffer = Buffer.from('abc');
-        const result = toMcpToolResult(new ImageContent({ data: buffer, mimeType: 'image/png' }));
+        const result = toMcpToolResult(new McpImageContent({ data: buffer, mimeType: 'image/png' }));
         expect(result?.type).to.equal('image');
         const content = JSON.parse(result?.content || '{}') as { type: string; data: string; mimeType: string };
         expect(content).to.deep.equal({ type: 'image', data: buffer.toString('base64'), mimeType: 'image/png' });
     });
 
-    it('serializes an AudioContent block', () => {
-        const result = toMcpToolResult(new AudioContent({ data: 'ZGF0YQ==', mimeType: 'audio/wav' }));
+    it('serializes an McpAudioContent block', () => {
+        const result = toMcpToolResult(new McpAudioContent({ data: 'ZGF0YQ==', mimeType: 'audio/wav' }));
         expect(result?.type).to.equal('audio');
         const content = JSON.parse(result?.content || '{}');
         expect(content).to.deep.equal({ type: 'audio', data: 'ZGF0YQ==', mimeType: 'audio/wav' });
     });
 
-    it('serializes a ResourceLinkContent block', () => {
+    it('serializes a McpResourceLinkContent block', () => {
         const result = toMcpToolResult(
-            new ResourceLinkContent({ uri: 'https://example.test/resource', name: 'example' })
+            new McpResourceLinkContent({ uri: 'https://example.test/resource', name: 'example' })
         );
         expect(result?.type).to.equal('resource_link');
         const content = JSON.parse(result?.content || '{}') as { type: string; uri: string; name: string };
@@ -98,8 +98,8 @@ describe('toMcpToolResult', () => {
 
     it('wraps arrays of content blocks as multi_content_result', () => {
         const result = toMcpToolResult([
-            new TextContent('first'),
-            new ImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' }),
+            new McpTextContent('first'),
+            new McpImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' }),
         ]);
         expect(result?.type).to.equal('multi_content_result');
         const content = JSON.parse(result?.content || '[]') as Array<{ type: string }>;
@@ -109,13 +109,13 @@ describe('toMcpToolResult', () => {
     });
 
     it('treats mixed arrays (non-content-block elements) as plain values', () => {
-        const result = toMcpToolResult([new TextContent('x'), { type: 'text', text: 'raw' }]);
+        const result = toMcpToolResult([new McpTextContent('x'), { type: 'text', text: 'raw' }]);
         expect(result?.type).to.equal('text');
     });
 
     it('serializes McpToolResponse with structuredContent', () => {
         const response = new McpToolResponse({
-            content: [new TextContent('display text')],
+            content: [new McpTextContent('display text')],
             structuredContent: { id: 'x1' },
         });
         const result = toMcpToolResult(response);
@@ -123,9 +123,9 @@ describe('toMcpToolResult', () => {
         expect(result?.structuredContent).to.equal(JSON.stringify({ id: 'x1' }));
     });
 
-    it('adds fallback text block when McpToolResponse has structuredContent but no TextContent', () => {
+    it('adds fallback text block when McpToolResponse has structuredContent but no McpTextContent', () => {
         const response = new McpToolResponse({
-            content: [new ImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' })],
+            content: [new McpImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' })],
             structuredContent: { id: 'x1' },
         });
         const result = toMcpToolResult(response);
@@ -138,7 +138,7 @@ describe('toMcpToolResult', () => {
 
     it('passes through string structuredContent without re-stringifying', () => {
         const response = new McpToolResponse({
-            content: [new TextContent('t')],
+            content: [new McpTextContent('t')],
             structuredContent: 'already-string',
         });
         const result = toMcpToolResult(response);
@@ -147,19 +147,19 @@ describe('toMcpToolResult', () => {
 
     it('does not emit structuredContent when explicitly null or undefined', () => {
         const nullResp = toMcpToolResult(
-            new McpToolResponse({ content: [new TextContent('t')], structuredContent: null })
+            new McpToolResponse({ content: [new McpTextContent('t')], structuredContent: null })
         );
         expect(nullResp?.structuredContent).to.equal(undefined);
 
         const undefResp = toMcpToolResult(
-            new McpToolResponse({ content: [new TextContent('t')], structuredContent: undefined })
+            new McpToolResponse({ content: [new McpTextContent('t')], structuredContent: undefined })
         );
         expect(undefResp?.structuredContent).to.equal(undefined);
     });
 
-    it('serializes a single ResourceContent block', () => {
+    it('serializes a single McpResourceContent block', () => {
         const result = toMcpToolResult(
-            new ResourceContent({ resource: { uri: 'mem://x', text: 'inline', mimeType: 'text/plain' } })
+            new McpResourceContent({ resource: { uri: 'mem://x', text: 'inline', mimeType: 'text/plain' } })
         );
         expect(result?.type).to.equal('resource');
         const content = JSON.parse(result?.content || '{}') as { type: string; resource: Record<string, unknown> };
@@ -169,10 +169,10 @@ describe('toMcpToolResult', () => {
         });
     });
 
-    it('serializes a ResourceContent block with base64-encoded blob', () => {
+    it('serializes a McpResourceContent block with base64-encoded blob', () => {
         const blob = Buffer.from('binary-data');
         const result = toMcpToolResult(
-            new ResourceContent({
+            new McpResourceContent({
                 resource: { uri: 'file:///a.bin', mimeType: 'application/octet-stream', blob },
             })
         );
@@ -191,9 +191,9 @@ describe('toMcpToolResult', () => {
         });
     });
 
-    it('serializes a ResourceContent block with only text (omits blob and mimeType)', () => {
+    it('serializes a McpResourceContent block with only text (omits blob and mimeType)', () => {
         const result = toMcpToolResult(
-            new ResourceContent({ resource: { uri: 'file:///a.txt', text: 'hello' } })
+            new McpResourceContent({ resource: { uri: 'file:///a.txt', text: 'hello' } })
         );
         const content = JSON.parse(result?.content || '{}') as { resource: Record<string, unknown> };
         expect(content.resource).to.deep.equal({ uri: 'file:///a.txt', text: 'hello' });
@@ -234,7 +234,7 @@ describe('toMcpToolResult', () => {
 
         const mixed = toMcpToolResult(
             new McpToolResponse({
-                content: [new TextContent('preview'), new VideoContent('YmFzZTY0', 'video/mp4')],
+                content: [new McpTextContent('preview'), new VideoContent('YmFzZTY0', 'video/mp4')],
                 structuredContent: { scenes: 3 },
             })
         );

--- a/test/converters/toMcpToolResult.test.ts
+++ b/test/converters/toMcpToolResult.test.ts
@@ -7,7 +7,9 @@ import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
 import {
     AudioContent,
     ImageContent,
+    McpContentBlock,
     McpToolResponse,
+    ResourceContent,
     ResourceLinkContent,
     TextContent,
 } from '../../src/mcp/McpToolResponse';
@@ -141,5 +143,105 @@ describe('toMcpToolResult', () => {
         });
         const result = toMcpToolResult(response);
         expect(result?.structuredContent).to.equal('already-string');
+    });
+
+    it('does not emit structuredContent when explicitly null or undefined', () => {
+        const nullResp = toMcpToolResult(
+            new McpToolResponse({ content: [new TextContent('t')], structuredContent: null })
+        );
+        expect(nullResp?.structuredContent).to.equal(undefined);
+
+        const undefResp = toMcpToolResult(
+            new McpToolResponse({ content: [new TextContent('t')], structuredContent: undefined })
+        );
+        expect(undefResp?.structuredContent).to.equal(undefined);
+    });
+
+    it('serializes a single ResourceContent block', () => {
+        const result = toMcpToolResult(
+            new ResourceContent({ resource: { uri: 'mem://x', text: 'inline', mimeType: 'text/plain' } })
+        );
+        expect(result?.type).to.equal('resource');
+        const content = JSON.parse(result?.content || '{}') as { type: string; resource: Record<string, unknown> };
+        expect(content).to.deep.equal({
+            type: 'resource',
+            resource: { uri: 'mem://x', text: 'inline', mimeType: 'text/plain' },
+        });
+    });
+
+    it('serializes a ResourceContent block with base64-encoded blob', () => {
+        const blob = Buffer.from('binary-data');
+        const result = toMcpToolResult(
+            new ResourceContent({
+                resource: { uri: 'file:///a.bin', mimeType: 'application/octet-stream', blob },
+            })
+        );
+        expect(result?.type).to.equal('resource');
+        const content = JSON.parse(result?.content || '{}') as {
+            type: string;
+            resource: Record<string, unknown>;
+        };
+        expect(content).to.deep.equal({
+            type: 'resource',
+            resource: {
+                uri: 'file:///a.bin',
+                mimeType: 'application/octet-stream',
+                blob: blob.toString('base64'),
+            },
+        });
+    });
+
+    it('serializes a ResourceContent block with only text (omits blob and mimeType)', () => {
+        const result = toMcpToolResult(
+            new ResourceContent({ resource: { uri: 'file:///a.txt', text: 'hello' } })
+        );
+        const content = JSON.parse(result?.content || '{}') as { resource: Record<string, unknown> };
+        expect(content.resource).to.deep.equal({ uri: 'file:///a.txt', text: 'hello' });
+        expect(content.resource).to.not.have.property('blob');
+        expect(content.resource).to.not.have.property('mimeType');
+    });
+
+    it('treats empty array as plain value (not a multi_content_result)', () => {
+        const result = toMcpToolResult([]);
+        expect(result?.type).to.equal('text');
+        const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
+        expect(content.type).to.equal('text');
+        expect(content.text).to.equal('[]');
+        expect(JSON.parse(content.text)).to.deep.equal([]);
+    });
+
+    it('accepts user-defined McpContentBlock subclasses (extensibility)', () => {
+        // Demonstrates the extensibility contract documented on McpContentBlock:
+        // a custom subclass flows through the converter with its own type/toJSON shape
+        // without any library changes.
+        class VideoContent extends McpContentBlock {
+            readonly type = 'video' as const;
+            constructor(private readonly data: string, private readonly mimeType: string) {
+                super();
+            }
+            toJSON(): Record<string, unknown> {
+                return { type: this.type, data: this.data, mimeType: this.mimeType };
+            }
+        }
+
+        const single = toMcpToolResult(new VideoContent('YmFzZTY0', 'video/mp4'));
+        expect(single?.type).to.equal('video');
+        expect(JSON.parse(single?.content || '{}')).to.deep.equal({
+            type: 'video',
+            data: 'YmFzZTY0',
+            mimeType: 'video/mp4',
+        });
+
+        const mixed = toMcpToolResult(
+            new McpToolResponse({
+                content: [new TextContent('preview'), new VideoContent('YmFzZTY0', 'video/mp4')],
+                structuredContent: { scenes: 3 },
+            })
+        );
+        expect(mixed?.type).to.equal('multi_content_result');
+        const blocks = JSON.parse(mixed?.content || '[]') as Array<{ type: string }>;
+        expect(blocks).to.have.length(2);
+        expect(blocks[1]?.type).to.equal('video');
+        expect(mixed?.structuredContent).to.equal(JSON.stringify({ scenes: 3 }));
     });
 });

--- a/test/converters/toMcpToolResult.test.ts
+++ b/test/converters/toMcpToolResult.test.ts
@@ -4,6 +4,13 @@
 import 'mocha';
 import { expect } from 'chai';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
+import {
+    AudioContent,
+    ImageContent,
+    McpToolResponse,
+    ResourceLinkContent,
+    TextContent,
+} from '../../src/mcp/McpToolResponse';
 import { McpContent } from '../../src/utils/mcpContentMarker';
 
 describe('toMcpToolResult', () => {
@@ -14,13 +21,9 @@ describe('toMcpToolResult', () => {
 
     it('wraps primitive string as text content', () => {
         const result = toMcpToolResult('hello');
-        expect(result).to.not.equal(undefined);
-        expect(result).to.not.equal(null);
         expect(result?.type).to.equal('text');
-
         const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
-        expect(content.type).to.equal('text');
-        expect(content.text).to.equal('hello');
+        expect(content).to.deep.equal({ type: 'text', text: 'hello' });
         expect(result?.structuredContent).to.equal(undefined);
     });
 
@@ -34,8 +37,8 @@ describe('toMcpToolResult', () => {
         class MarkedPayload {
             constructor(public id: string) {}
         }
-
         McpContent(MarkedPayload);
+
         const instance = new MarkedPayload('p1');
         const result = toMcpToolResult(instance);
 
@@ -43,26 +46,59 @@ describe('toMcpToolResult', () => {
         expect(result?.structuredContent).to.equal(JSON.stringify(instance));
     });
 
-    it('converts direct image block and normalizes buffer data to base64', () => {
-        const buffer = Buffer.from('abc');
-        const result = toMcpToolResult({
-            type: 'image',
-            data: buffer,
-            mimeType: 'image/png',
-        });
-
-        expect(result?.type).to.equal('image');
-        const content = JSON.parse(result?.content || '{}') as { type: string; data: string };
-        expect(content.type).to.equal('image');
-        expect(content.data).to.equal(buffer.toString('base64'));
+    it('treats plain object with content array as a plain value (not a CallToolResult)', () => {
+        // Previously the structural CallToolResult detector would misclassify this.
+        // With class-based detection it must be serialized as plain text.
+        const result = toMcpToolResult({ content: ['hello'], status: 'ok' });
+        expect(result?.type).to.equal('text');
+        const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
+        expect(content.type).to.equal('text');
+        expect(JSON.parse(content.text)).to.deep.equal({ content: ['hello'], status: 'ok' });
     });
 
-    it('wraps direct content block arrays as multi_content_result', () => {
-        const result = toMcpToolResult([
-            { type: 'text', text: 'first' },
-            { type: 'image', data: 'ZGF0YQ==', mimeType: 'image/png' },
-        ]);
+    it('treats user domain object with type field as a plain value', () => {
+        // Previously { type: 'report', content: '...' } would be misclassified as an MCP result.
+        const result = toMcpToolResult({ type: 'report', content: 'quarterly results' });
+        expect(result?.type).to.equal('text');
+        const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
+        expect(JSON.parse(content.text)).to.deep.equal({ type: 'report', content: 'quarterly results' });
+    });
 
+    it('serializes a single TextContent block', () => {
+        const result = toMcpToolResult(new TextContent('hi there'));
+        expect(result?.type).to.equal('text');
+        expect(JSON.parse(result?.content || '{}')).to.deep.equal({ type: 'text', text: 'hi there' });
+    });
+
+    it('serializes an ImageContent block and normalizes Buffer data to base64', () => {
+        const buffer = Buffer.from('abc');
+        const result = toMcpToolResult(new ImageContent({ data: buffer, mimeType: 'image/png' }));
+        expect(result?.type).to.equal('image');
+        const content = JSON.parse(result?.content || '{}') as { type: string; data: string; mimeType: string };
+        expect(content).to.deep.equal({ type: 'image', data: buffer.toString('base64'), mimeType: 'image/png' });
+    });
+
+    it('serializes an AudioContent block', () => {
+        const result = toMcpToolResult(new AudioContent({ data: 'ZGF0YQ==', mimeType: 'audio/wav' }));
+        expect(result?.type).to.equal('audio');
+        const content = JSON.parse(result?.content || '{}');
+        expect(content).to.deep.equal({ type: 'audio', data: 'ZGF0YQ==', mimeType: 'audio/wav' });
+    });
+
+    it('serializes a ResourceLinkContent block', () => {
+        const result = toMcpToolResult(
+            new ResourceLinkContent({ uri: 'https://example.test/resource', name: 'example' })
+        );
+        expect(result?.type).to.equal('resource_link');
+        const content = JSON.parse(result?.content || '{}') as { type: string; uri: string; name: string };
+        expect(content).to.deep.equal({ type: 'resource_link', uri: 'https://example.test/resource', name: 'example' });
+    });
+
+    it('wraps arrays of content blocks as multi_content_result', () => {
+        const result = toMcpToolResult([
+            new TextContent('first'),
+            new ImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' }),
+        ]);
         expect(result?.type).to.equal('multi_content_result');
         const content = JSON.parse(result?.content || '[]') as Array<{ type: string }>;
         expect(content).to.have.length(2);
@@ -70,12 +106,27 @@ describe('toMcpToolResult', () => {
         expect(content[1]?.type).to.equal('image');
     });
 
-    it('adds fallback text block for CallToolResult with structuredContent and no text block', () => {
-        const result = toMcpToolResult({
-            content: [{ type: 'image', data: 'ZGF0YQ==', mimeType: 'image/png' }],
+    it('treats mixed arrays (non-content-block elements) as plain values', () => {
+        const result = toMcpToolResult([new TextContent('x'), { type: 'text', text: 'raw' }]);
+        expect(result?.type).to.equal('text');
+    });
+
+    it('serializes McpToolResponse with structuredContent', () => {
+        const response = new McpToolResponse({
+            content: [new TextContent('display text')],
             structuredContent: { id: 'x1' },
         });
+        const result = toMcpToolResult(response);
+        expect(result?.type).to.equal('text');
+        expect(result?.structuredContent).to.equal(JSON.stringify({ id: 'x1' }));
+    });
 
+    it('adds fallback text block when McpToolResponse has structuredContent but no TextContent', () => {
+        const response = new McpToolResponse({
+            content: [new ImageContent({ data: 'ZGF0YQ==', mimeType: 'image/png' })],
+            structuredContent: { id: 'x1' },
+        });
+        const result = toMcpToolResult(response);
         expect(result?.type).to.equal('multi_content_result');
         const content = JSON.parse(result?.content || '[]') as Array<{ type: string; text?: string }>;
         expect(content).to.have.length(2);
@@ -83,26 +134,12 @@ describe('toMcpToolResult', () => {
         expect(result?.structuredContent).to.equal(JSON.stringify({ id: 'x1' }));
     });
 
-    it('normalizes existing McpToolResult when content is not a string', () => {
-        const result = toMcpToolResult({
-            type: 'text',
-            content: { type: 'text', text: 'normalized' },
+    it('passes through string structuredContent without re-stringifying', () => {
+        const response = new McpToolResponse({
+            content: [new TextContent('t')],
+            structuredContent: 'already-string',
         });
-
-        expect(result?.type).to.equal('text');
-        expect(result?.content).to.equal(JSON.stringify({ type: 'text', text: 'normalized' }));
-    });
-
-    it('treats resource_link blocks as direct content blocks', () => {
-        const result = toMcpToolResult({
-            type: 'resource_link',
-            uri: 'https://example.test/resource',
-            name: 'example',
-        });
-
-        expect(result?.type).to.equal('resource_link');
-        const content = JSON.parse(result?.content || '{}') as { type: string; uri: string };
-        expect(content.type).to.equal('resource_link');
-        expect(content.uri).to.equal('https://example.test/resource');
+        const result = toMcpToolResult(response);
+        expect(result?.structuredContent).to.equal('already-string');
     });
 });

--- a/test/mcp/McpToolResponse.test.ts
+++ b/test/mcp/McpToolResponse.test.ts
@@ -4,29 +4,29 @@
 import 'mocha';
 import { expect } from 'chai';
 import {
-    AudioContent,
-    ImageContent,
+    McpAudioContent,
+    McpImageContent,
     McpContentBlock,
     McpToolResponse,
-    ResourceContent,
-    ResourceLinkContent,
-    TextContent,
+    McpResourceContent,
+    McpResourceLinkContent,
+    McpTextContent,
 } from '../../src/mcp/McpToolResponse';
 
 describe('MCP content block classes', () => {
     describe('McpContentBlock inheritance', () => {
         it('built-in classes are instances of McpContentBlock', () => {
-            expect(new TextContent('x')).to.be.instanceOf(McpContentBlock);
-            expect(new ImageContent({ data: 'a', mimeType: 'image/png' })).to.be.instanceOf(McpContentBlock);
-            expect(new AudioContent({ data: 'a', mimeType: 'audio/wav' })).to.be.instanceOf(McpContentBlock);
-            expect(new ResourceLinkContent({ uri: 'u' })).to.be.instanceOf(McpContentBlock);
-            expect(new ResourceContent({ resource: { uri: 'u' } })).to.be.instanceOf(McpContentBlock);
+            expect(new McpTextContent('x')).to.be.instanceOf(McpContentBlock);
+            expect(new McpImageContent({ data: 'a', mimeType: 'image/png' })).to.be.instanceOf(McpContentBlock);
+            expect(new McpAudioContent({ data: 'a', mimeType: 'audio/wav' })).to.be.instanceOf(McpContentBlock);
+            expect(new McpResourceLinkContent({ uri: 'u' })).to.be.instanceOf(McpContentBlock);
+            expect(new McpResourceContent({ resource: { uri: 'u' } })).to.be.instanceOf(McpContentBlock);
         });
     });
 
-    describe('TextContent', () => {
+    describe('McpTextContent', () => {
         it('stores text and emits the canonical wire shape', () => {
-            const block = new TextContent('hi');
+            const block = new McpTextContent('hi');
             expect(block.type).to.equal('text');
             expect(block.text).to.equal('hi');
             expect(block.toJSON()).to.deep.equal({ type: 'text', text: 'hi' });
@@ -34,58 +34,58 @@ describe('MCP content block classes', () => {
         });
 
         it('handles empty string', () => {
-            expect(new TextContent('').toJSON()).to.deep.equal({ type: 'text', text: '' });
+            expect(new McpTextContent('').toJSON()).to.deep.equal({ type: 'text', text: '' });
         });
     });
 
-    describe('ImageContent', () => {
+    describe('McpImageContent', () => {
         it('passes through string data unchanged', () => {
-            const json = new ImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' }).toJSON();
+            const json = new McpImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' }).toJSON();
             expect(json).to.deep.equal({ type: 'image', data: 'YmFzZTY0', mimeType: 'image/png' });
         });
 
         it('base64-encodes Buffer data', () => {
             const buf = Buffer.from('abc');
-            const json = new ImageContent({ data: buf, mimeType: 'image/png' }).toJSON();
+            const json = new McpImageContent({ data: buf, mimeType: 'image/png' }).toJSON();
             expect(json.data).to.equal(buf.toString('base64'));
         });
 
         it('base64-encodes ArrayBuffer data', () => {
             const ab = new ArrayBuffer(3);
             new Uint8Array(ab).set([97, 98, 99]); // 'abc'
-            const json = new ImageContent({ data: ab, mimeType: 'image/png' }).toJSON();
+            const json = new McpImageContent({ data: ab, mimeType: 'image/png' }).toJSON();
             expect(json.data).to.equal(Buffer.from('abc').toString('base64'));
         });
 
         it('base64-encodes ArrayBufferView (Uint8Array) data', () => {
             const view = new Uint8Array([97, 98, 99]);
-            const json = new ImageContent({ data: view, mimeType: 'image/png' }).toJSON();
+            const json = new McpImageContent({ data: view, mimeType: 'image/png' }).toJSON();
             expect(json.data).to.equal(Buffer.from('abc').toString('base64'));
         });
 
         it('omits mimeType when undefined', () => {
-            const json = new ImageContent({ data: 'abc' }).toJSON();
+            const json = new McpImageContent({ data: 'abc' }).toJSON();
             expect(json).to.deep.equal({ type: 'image', data: 'abc' });
             expect('mimeType' in json).to.equal(false);
         });
     });
 
-    describe('AudioContent', () => {
+    describe('McpAudioContent', () => {
         it('base64-encodes Buffer data and preserves mimeType', () => {
             const buf = Buffer.from('xyz');
-            const json = new AudioContent({ data: buf, mimeType: 'audio/wav' }).toJSON();
+            const json = new McpAudioContent({ data: buf, mimeType: 'audio/wav' }).toJSON();
             expect(json).to.deep.equal({ type: 'audio', data: buf.toString('base64'), mimeType: 'audio/wav' });
         });
 
         it('omits mimeType when undefined', () => {
-            const json = new AudioContent({ data: 'abc' }).toJSON();
+            const json = new McpAudioContent({ data: 'abc' }).toJSON();
             expect(json).to.deep.equal({ type: 'audio', data: 'abc' });
         });
     });
 
-    describe('ResourceLinkContent', () => {
+    describe('McpResourceLinkContent', () => {
         it('emits all fields when provided', () => {
-            const json = new ResourceLinkContent({
+            const json = new McpResourceLinkContent({
                 uri: 'https://example.test',
                 name: 'n',
                 description: 'd',
@@ -101,7 +101,7 @@ describe('MCP content block classes', () => {
         });
 
         it('omits optional fields when undefined', () => {
-            const json = new ResourceLinkContent({ uri: 'https://example.test' }).toJSON();
+            const json = new McpResourceLinkContent({ uri: 'https://example.test' }).toJSON();
             expect(json).to.deep.equal({ type: 'resource_link', uri: 'https://example.test' });
             expect('name' in json).to.equal(false);
             expect('description' in json).to.equal(false);
@@ -109,9 +109,9 @@ describe('MCP content block classes', () => {
         });
     });
 
-    describe('ResourceContent', () => {
+    describe('McpResourceContent', () => {
         it('emits a text resource with only uri + text', () => {
-            const json = new ResourceContent({
+            const json = new McpResourceContent({
                 resource: { uri: 'mem://x', text: 'inline' },
             }).toJSON();
             expect(json).to.deep.equal({ type: 'resource', resource: { uri: 'mem://x', text: 'inline' } });
@@ -119,7 +119,7 @@ describe('MCP content block classes', () => {
 
         it('base64-encodes Buffer blob', () => {
             const buf = Buffer.from('abc');
-            const json = new ResourceContent({
+            const json = new McpResourceContent({
                 resource: { uri: 'mem://x', blob: buf, mimeType: 'application/octet-stream' },
             }).toJSON() as { resource: { blob: string; mimeType: string; uri: string } };
             expect(json.resource.blob).to.equal(buf.toString('base64'));
@@ -127,7 +127,7 @@ describe('MCP content block classes', () => {
         });
 
         it('omits optional fields when undefined', () => {
-            const json = new ResourceContent({ resource: { uri: 'mem://x' } }).toJSON() as {
+            const json = new McpResourceContent({ resource: { uri: 'mem://x' } }).toJSON() as {
                 resource: Record<string, unknown>;
             };
             expect(json.resource).to.deep.equal({ uri: 'mem://x' });
@@ -136,7 +136,7 @@ describe('MCP content block classes', () => {
 
     describe('McpToolResponse constructor', () => {
         it('accepts content-only init', () => {
-            const r = new McpToolResponse({ content: [new TextContent('x')] });
+            const r = new McpToolResponse({ content: [new McpTextContent('x')] });
             expect(r.content).to.have.length(1);
             expect(r.structuredContent).to.equal(undefined);
             expect(r.isError).to.equal(undefined);
@@ -144,7 +144,7 @@ describe('MCP content block classes', () => {
 
         it('accepts structuredContent and isError', () => {
             const r = new McpToolResponse({
-                content: [new TextContent('x')],
+                content: [new McpTextContent('x')],
                 structuredContent: { id: 'x' },
                 isError: true,
             });

--- a/test/mcp/McpToolResponse.test.ts
+++ b/test/mcp/McpToolResponse.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import {
+    AudioContent,
+    ImageContent,
+    McpContentBlock,
+    McpToolResponse,
+    ResourceContent,
+    ResourceLinkContent,
+    TextContent,
+} from '../../src/mcp/McpToolResponse';
+
+describe('MCP content block classes', () => {
+    describe('McpContentBlock inheritance', () => {
+        it('built-in classes are instances of McpContentBlock', () => {
+            expect(new TextContent('x')).to.be.instanceOf(McpContentBlock);
+            expect(new ImageContent({ data: 'a', mimeType: 'image/png' })).to.be.instanceOf(McpContentBlock);
+            expect(new AudioContent({ data: 'a', mimeType: 'audio/wav' })).to.be.instanceOf(McpContentBlock);
+            expect(new ResourceLinkContent({ uri: 'u' })).to.be.instanceOf(McpContentBlock);
+            expect(new ResourceContent({ resource: { uri: 'u' } })).to.be.instanceOf(McpContentBlock);
+        });
+    });
+
+    describe('TextContent', () => {
+        it('stores text and emits the canonical wire shape', () => {
+            const block = new TextContent('hi');
+            expect(block.type).to.equal('text');
+            expect(block.text).to.equal('hi');
+            expect(block.toJSON()).to.deep.equal({ type: 'text', text: 'hi' });
+            expect(JSON.parse(JSON.stringify(block))).to.deep.equal({ type: 'text', text: 'hi' });
+        });
+
+        it('handles empty string', () => {
+            expect(new TextContent('').toJSON()).to.deep.equal({ type: 'text', text: '' });
+        });
+    });
+
+    describe('ImageContent', () => {
+        it('passes through string data unchanged', () => {
+            const json = new ImageContent({ data: 'YmFzZTY0', mimeType: 'image/png' }).toJSON();
+            expect(json).to.deep.equal({ type: 'image', data: 'YmFzZTY0', mimeType: 'image/png' });
+        });
+
+        it('base64-encodes Buffer data', () => {
+            const buf = Buffer.from('abc');
+            const json = new ImageContent({ data: buf, mimeType: 'image/png' }).toJSON();
+            expect(json.data).to.equal(buf.toString('base64'));
+        });
+
+        it('base64-encodes ArrayBuffer data', () => {
+            const ab = new ArrayBuffer(3);
+            new Uint8Array(ab).set([97, 98, 99]); // 'abc'
+            const json = new ImageContent({ data: ab, mimeType: 'image/png' }).toJSON();
+            expect(json.data).to.equal(Buffer.from('abc').toString('base64'));
+        });
+
+        it('base64-encodes ArrayBufferView (Uint8Array) data', () => {
+            const view = new Uint8Array([97, 98, 99]);
+            const json = new ImageContent({ data: view, mimeType: 'image/png' }).toJSON();
+            expect(json.data).to.equal(Buffer.from('abc').toString('base64'));
+        });
+
+        it('omits mimeType when undefined', () => {
+            const json = new ImageContent({ data: 'abc' }).toJSON();
+            expect(json).to.deep.equal({ type: 'image', data: 'abc' });
+            expect('mimeType' in json).to.equal(false);
+        });
+    });
+
+    describe('AudioContent', () => {
+        it('base64-encodes Buffer data and preserves mimeType', () => {
+            const buf = Buffer.from('xyz');
+            const json = new AudioContent({ data: buf, mimeType: 'audio/wav' }).toJSON();
+            expect(json).to.deep.equal({ type: 'audio', data: buf.toString('base64'), mimeType: 'audio/wav' });
+        });
+
+        it('omits mimeType when undefined', () => {
+            const json = new AudioContent({ data: 'abc' }).toJSON();
+            expect(json).to.deep.equal({ type: 'audio', data: 'abc' });
+        });
+    });
+
+    describe('ResourceLinkContent', () => {
+        it('emits all fields when provided', () => {
+            const json = new ResourceLinkContent({
+                uri: 'https://example.test',
+                name: 'n',
+                description: 'd',
+                mimeType: 'text/plain',
+            }).toJSON();
+            expect(json).to.deep.equal({
+                type: 'resource_link',
+                uri: 'https://example.test',
+                name: 'n',
+                description: 'd',
+                mimeType: 'text/plain',
+            });
+        });
+
+        it('omits optional fields when undefined', () => {
+            const json = new ResourceLinkContent({ uri: 'https://example.test' }).toJSON();
+            expect(json).to.deep.equal({ type: 'resource_link', uri: 'https://example.test' });
+            expect('name' in json).to.equal(false);
+            expect('description' in json).to.equal(false);
+            expect('mimeType' in json).to.equal(false);
+        });
+    });
+
+    describe('ResourceContent', () => {
+        it('emits a text resource with only uri + text', () => {
+            const json = new ResourceContent({
+                resource: { uri: 'mem://x', text: 'inline' },
+            }).toJSON();
+            expect(json).to.deep.equal({ type: 'resource', resource: { uri: 'mem://x', text: 'inline' } });
+        });
+
+        it('base64-encodes Buffer blob', () => {
+            const buf = Buffer.from('abc');
+            const json = new ResourceContent({
+                resource: { uri: 'mem://x', blob: buf, mimeType: 'application/octet-stream' },
+            }).toJSON() as { resource: { blob: string; mimeType: string; uri: string } };
+            expect(json.resource.blob).to.equal(buf.toString('base64'));
+            expect(json.resource.mimeType).to.equal('application/octet-stream');
+        });
+
+        it('omits optional fields when undefined', () => {
+            const json = new ResourceContent({ resource: { uri: 'mem://x' } }).toJSON() as {
+                resource: Record<string, unknown>;
+            };
+            expect(json.resource).to.deep.equal({ uri: 'mem://x' });
+        });
+    });
+
+    describe('McpToolResponse constructor', () => {
+        it('accepts content-only init', () => {
+            const r = new McpToolResponse({ content: [new TextContent('x')] });
+            expect(r.content).to.have.length(1);
+            expect(r.structuredContent).to.equal(undefined);
+            expect(r.isError).to.equal(undefined);
+        });
+
+        it('accepts structuredContent and isError', () => {
+            const r = new McpToolResponse({
+                content: [new TextContent('x')],
+                structuredContent: { id: 'x' },
+                isError: true,
+            });
+            expect(r.structuredContent).to.deep.equal({ id: 'x' });
+            expect(r.isError).to.equal(true);
+        });
+    });
+});

--- a/test/mcp/sdkCompat.test.ts
+++ b/test/mcp/sdkCompat.test.ts
@@ -5,7 +5,7 @@ import 'mocha';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
-import { McpToolResponse, TextContent } from '../../src/mcp/McpToolResponse';
+import { McpToolResponse, McpTextContent } from '../../src/mcp/McpToolResponse';
 import { __resetMcpSdkWarning } from '../../src/mcp/sdkCompat';
 
 describe('MCP SDK compat', () => {
@@ -48,9 +48,9 @@ describe('MCP SDK compat', () => {
         });
 
         it('does not warn when proper classes are used', () => {
-            toMcpToolResult(new TextContent('x'));
-            toMcpToolResult(new McpToolResponse({ content: [new TextContent('x')] }));
-            toMcpToolResult([new TextContent('a'), new TextContent('b')]);
+            toMcpToolResult(new McpTextContent('x'));
+            toMcpToolResult(new McpToolResponse({ content: [new McpTextContent('x')] }));
+            toMcpToolResult([new McpTextContent('a'), new McpTextContent('b')]);
             expect(warnStub.notCalled).to.equal(true);
         });
 

--- a/test/mcp/sdkCompat.test.ts
+++ b/test/mcp/sdkCompat.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
+import { McpToolResponse, TextContent } from '../../src/mcp/McpToolResponse';
+import { __resetMcpSdkWarning } from '../../src/mcp/sdkCompat';
+
+describe('MCP SDK compat', () => {
+    let warnStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        __resetMcpSdkWarning();
+        warnStub = sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+        warnStub.restore();
+        __resetMcpSdkWarning();
+    });
+
+    describe('one-time warning on SDK-shaped values', () => {
+        it('warns when value has a content array', () => {
+            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] });
+            expect(warnStub.calledOnce).to.equal(true);
+            expect(warnStub.firstCall.args[0]).to.match(/looks like an @modelcontextprotocol\/sdk response/);
+        });
+
+        it('warns when value has type + text/data/uri/resource', () => {
+            toMcpToolResult({ type: 'text', text: 'x' });
+            expect(warnStub.calledOnce).to.equal(true);
+        });
+
+        it('does not warn for unrelated plain values', () => {
+            toMcpToolResult({ id: 'plain' });
+            toMcpToolResult('hello');
+            toMcpToolResult(42);
+            expect(warnStub.notCalled).to.equal(true);
+        });
+
+        it('only warns once across multiple invocations', () => {
+            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] });
+            toMcpToolResult({ type: 'text', text: 'y' });
+            toMcpToolResult({ content: [] });
+            expect(warnStub.callCount).to.equal(1);
+        });
+
+        it('does not warn when proper classes are used', () => {
+            toMcpToolResult(new TextContent('x'));
+            toMcpToolResult(new McpToolResponse({ content: [new TextContent('x')] }));
+            toMcpToolResult([new TextContent('a'), new TextContent('b')]);
+            expect(warnStub.notCalled).to.equal(true);
+        });
+
+        it('does not change behavior when warning fires (still serializes as plain text)', () => {
+            const result = toMcpToolResult({ type: 'text', text: 'x' });
+            expect(result?.type).to.equal('text');
+            const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
+            expect(JSON.parse(content.text)).to.deep.equal({ type: 'text', text: 'x' });
+        });
+    });
+});

--- a/test/mcp/sdkCompat.test.ts
+++ b/test/mcp/sdkCompat.test.ts
@@ -4,58 +4,70 @@
 import 'mocha';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import type { InvocationContext } from '@azure/functions';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
 import { McpToolResponse, McpTextContent } from '../../src/mcp/McpToolResponse';
 import { __resetMcpSdkWarning } from '../../src/mcp/sdkCompat';
 
 describe('MCP SDK compat', () => {
     let warnStub: sinon.SinonStub;
+    let context: InvocationContext;
 
     beforeEach(() => {
         __resetMcpSdkWarning();
-        warnStub = sinon.stub(console, 'warn');
+        warnStub = sinon.stub();
+        context = { warn: warnStub } as unknown as InvocationContext;
     });
 
     afterEach(() => {
-        warnStub.restore();
         __resetMcpSdkWarning();
     });
 
     describe('one-time warning on SDK-shaped values', () => {
-        it('warns when value has a content array', () => {
-            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] });
+        it('warns via the supplied logger when value has a content array', () => {
+            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] }, context);
             expect(warnStub.calledOnce).to.equal(true);
-            expect(warnStub.firstCall.args[0]).to.match(/looks like an @modelcontextprotocol\/sdk response/);
+            expect(warnStub.firstCall.args[0]).to.match(/@modelcontextprotocol\/sdk/);
         });
 
         it('warns when value has type + text/data/uri/resource', () => {
-            toMcpToolResult({ type: 'text', text: 'x' });
+            toMcpToolResult({ type: 'text', text: 'x' }, context);
             expect(warnStub.calledOnce).to.equal(true);
         });
 
         it('does not warn for unrelated plain values', () => {
-            toMcpToolResult({ id: 'plain' });
-            toMcpToolResult('hello');
-            toMcpToolResult(42);
+            toMcpToolResult({ id: 'plain' }, context);
+            toMcpToolResult('hello', context);
+            toMcpToolResult(42, context);
             expect(warnStub.notCalled).to.equal(true);
         });
 
         it('only warns once across multiple invocations', () => {
-            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] });
-            toMcpToolResult({ type: 'text', text: 'y' });
-            toMcpToolResult({ content: [] });
+            toMcpToolResult({ content: [{ type: 'text', text: 'x' }] }, context);
+            toMcpToolResult({ type: 'text', text: 'y' }, context);
+            toMcpToolResult({ content: [] }, context);
             expect(warnStub.callCount).to.equal(1);
         });
 
         it('does not warn when proper classes are used', () => {
-            toMcpToolResult(new McpTextContent('x'));
-            toMcpToolResult(new McpToolResponse({ content: [new McpTextContent('x')] }));
-            toMcpToolResult([new McpTextContent('a'), new McpTextContent('b')]);
+            toMcpToolResult(new McpTextContent('x'), context);
+            toMcpToolResult(new McpToolResponse({ content: [new McpTextContent('x')] }), context);
+            toMcpToolResult([new McpTextContent('a'), new McpTextContent('b')], context);
             expect(warnStub.notCalled).to.equal(true);
         });
 
+        it('does not warn when no logger is supplied, even for SDK-shaped values', () => {
+            const consoleWarn = sinon.stub(console, 'warn');
+            try {
+                toMcpToolResult({ content: [{ type: 'text', text: 'x' }] });
+                expect(consoleWarn.notCalled).to.equal(true);
+            } finally {
+                consoleWarn.restore();
+            }
+        });
+
         it('does not change behavior when warning fires (still serializes as plain text)', () => {
-            const result = toMcpToolResult({ type: 'text', text: 'x' });
+            const result = toMcpToolResult({ type: 'text', text: 'x' }, context);
             expect(result?.type).to.equal('text');
             const content = JSON.parse(result?.content || '{}') as { type: string; text: string };
             expect(JSON.parse(content.text)).to.deep.equal({ type: 'text', text: 'x' });

--- a/types/mcpContentMarker.d.ts
+++ b/types/mcpContentMarker.d.ts
@@ -10,7 +10,7 @@
  * and structured content (for clients that support it).
  *
  * Without the marker, a plain object is serialized as text-only (JSON stringified).
- * Use `CallToolResult` if you need explicit control over structuredContent without a class.
+ * Use `McpToolResponse` if you need explicit control over structuredContent without a class.
  *
  * **Programmatic usage** (works without `experimentalDecorators`):
  * ```typescript
@@ -40,8 +40,8 @@
  * @param target - Optional class or constructor function to mark for structured content.
  * @returns The target class/function unchanged or a class decorator.
  *
- * @see {@link CallToolResult} - For explicit content blocks + structuredContent
- * @see {@link ImageContentBlock | TextContentBlock} - For returning single content blocks
+ * @see {@link McpToolResponse} - For explicit content blocks + structuredContent
+ * @see {@link TextContent} - For returning single content blocks
  */
 export function McpContent<T extends { new (...args: any[]): unknown }>(target: T): T;
 export function McpContent(): <T extends { new (...args: any[]): unknown }>(target: T) => T;

--- a/types/mcpContentMarker.d.ts
+++ b/types/mcpContentMarker.d.ts
@@ -41,7 +41,7 @@
  * @returns The target class/function unchanged or a class decorator.
  *
  * @see {@link McpToolResponse} - For explicit content blocks + structuredContent
- * @see {@link TextContent} - For returning single content blocks
+ * @see {@link McpTextContent} - For returning single content blocks
  */
 export function McpContent<T extends { new (...args: any[]): unknown }>(target: T): T;
 export function McpContent(): <T extends { new (...args: any[]): unknown }>(target: T) => T;

--- a/types/mcpTool.d.ts
+++ b/types/mcpTool.d.ts
@@ -161,6 +161,86 @@ export type Args = Record<string, Arg>;
  *
  * Plain object literals like `{ type: 'text', text: '...' }` are **not** treated as
  * content blocks and will be serialized as JSON text instead.
+ *
+ * ## Extending with custom content block types
+ *
+ * If the MCP spec adds a new block type — or your scenario needs a custom one — you can
+ * ship your own subclass without any library change. The converter only checks
+ * `instanceof McpContentBlock` and calls `JSON.stringify(block)`, which invokes your
+ * `toJSON()` to produce the wire payload.
+ *
+ * ### Example: adding a hypothetical `VideoContent`
+ *
+ * ```ts
+ * import { McpContentBlock } from '@azure/functions';
+ *
+ * export interface VideoContentInit {
+ *     data: string | Buffer | ArrayBuffer;
+ *     mimeType: string;          // e.g. 'video/mp4'
+ *     durationMs?: number;       // optional field from a hypothetical spec
+ * }
+ *
+ * export class VideoContent extends McpContentBlock {
+ *     readonly type = 'video' as const;
+ *     readonly data: string | Buffer | ArrayBuffer;
+ *     readonly mimeType: string;
+ *     readonly durationMs?: number;
+ *
+ *     constructor(init: VideoContentInit) {
+ *         super();
+ *         this.data = init.data;
+ *         this.mimeType = init.mimeType;
+ *         this.durationMs = init.durationMs;
+ *     }
+ *
+ *     toJSON(): Record<string, unknown> {
+ *         const out: Record<string, unknown> = {
+ *             type: this.type,
+ *             data: toBase64(this.data),
+ *             mimeType: this.mimeType,
+ *         };
+ *         if (this.durationMs !== undefined) out.durationMs = this.durationMs;
+ *         return out;
+ *     }
+ * }
+ *
+ * function toBase64(data: string | Buffer | ArrayBuffer): string {
+ *     if (typeof data === 'string') return data;
+ *     if (Buffer.isBuffer(data)) return data.toString('base64');
+ *     return Buffer.from(new Uint8Array(data)).toString('base64');
+ * }
+ * ```
+ *
+ * ### Using a custom block from a tool handler
+ *
+ * ```ts
+ * // Single block
+ * handler: async () => new VideoContent({ data: buf, mimeType: 'video/mp4' })
+ *
+ * // Mixed with built-ins + structured content
+ * handler: async () => new McpToolResponse({
+ *     content: [
+ *         new TextContent('Detected 3 scenes'),
+ *         new VideoContent({ data: buf, mimeType: 'video/mp4' }),
+ *     ],
+ *     structuredContent: { scenes: 3, confidence: 0.92 },
+ * })
+ * ```
+ *
+ * ### What the library does for you
+ *
+ *  - `instanceof McpContentBlock` treats your subclass identically to built-in blocks.
+ *  - Single-block returns propagate your `type` string to the outer result; arrays are
+ *    wrapped as `multi_content_result`.
+ *  - `structuredContent` handling, fallback-text synthesis, and nullish passthrough all
+ *    apply unchanged.
+ *
+ * ### What you must get right in your subclass
+ *
+ *  - `toJSON()` must return the exact wire shape the spec requires for your `type`.
+ *  - Binary payloads should be base64-encoded in `toJSON()` (see the `toBase64` helper
+ *    above).
+ *  - Plain object literals are **not** recognized — you must construct an instance.
  */
 export declare abstract class McpContentBlock {
     abstract readonly type: string;

--- a/types/mcpTool.d.ts
+++ b/types/mcpTool.d.ts
@@ -156,7 +156,7 @@ export type Args = Record<string, Arg>;
  *
  * The Azure Functions library discriminates content blocks from plain user values using
  * `instanceof McpContentBlock`, so only instances of the built-in subclasses
- * (`TextContent`, `ImageContent`, `AudioContent`, `ResourceLinkContent`, `ResourceContent`)
+ * (`McpTextContent`, `McpImageContent`, `McpAudioContent`, `McpResourceLinkContent`, `McpResourceContent`)
  * — or a custom subclass that extends this class — will be treated as content blocks.
  *
  * Plain object literals like `{ type: 'text', text: '...' }` are **not** treated as
@@ -220,7 +220,7 @@ export type Args = Record<string, Arg>;
  * // Mixed with built-ins + structured content
  * handler: async () => new McpToolResponse({
  *     content: [
- *         new TextContent('Detected 3 scenes'),
+ *         new McpTextContent('Detected 3 scenes'),
  *         new VideoContent({ data: buf, mimeType: 'video/mp4' }),
  *     ],
  *     structuredContent: { scenes: 3, confidence: 0.92 },
@@ -248,45 +248,45 @@ export declare abstract class McpContentBlock {
 }
 
 /** A text content block in an MCP tool response. */
-export declare class TextContent extends McpContentBlock {
+export declare class McpTextContent extends McpContentBlock {
     readonly type: 'text';
     readonly text: string;
     constructor(text: string);
     toJSON(): Record<string, unknown>;
 }
 
-/** Initializer for `ImageContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
-export interface ImageContentInit {
+/** Initializer for `McpImageContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface McpImageContentInit {
     data: string | Buffer | ArrayBuffer;
     mimeType?: string;
 }
 
 /** An image content block in an MCP tool response. */
-export declare class ImageContent extends McpContentBlock {
+export declare class McpImageContent extends McpContentBlock {
     readonly type: 'image';
     readonly data: string | Buffer | ArrayBuffer;
     readonly mimeType?: string;
-    constructor(init: ImageContentInit);
+    constructor(init: McpImageContentInit);
     toJSON(): Record<string, unknown>;
 }
 
-/** Initializer for `AudioContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
-export interface AudioContentInit {
+/** Initializer for `McpAudioContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface McpAudioContentInit {
     data: string | Buffer | ArrayBuffer;
     mimeType?: string;
 }
 
 /** An audio content block in an MCP tool response. */
-export declare class AudioContent extends McpContentBlock {
+export declare class McpAudioContent extends McpContentBlock {
     readonly type: 'audio';
     readonly data: string | Buffer | ArrayBuffer;
     readonly mimeType?: string;
-    constructor(init: AudioContentInit);
+    constructor(init: McpAudioContentInit);
     toJSON(): Record<string, unknown>;
 }
 
-/** Initializer for `ResourceLinkContent`. */
-export interface ResourceLinkContentInit {
+/** Initializer for `McpResourceLinkContent`. */
+export interface McpResourceLinkContentInit {
     uri: string;
     name?: string;
     description?: string;
@@ -294,18 +294,18 @@ export interface ResourceLinkContentInit {
 }
 
 /** A resource-link content block in an MCP tool response. */
-export declare class ResourceLinkContent extends McpContentBlock {
+export declare class McpResourceLinkContent extends McpContentBlock {
     readonly type: 'resource_link';
     readonly uri: string;
     readonly name?: string;
     readonly description?: string;
     readonly mimeType?: string;
-    constructor(init: ResourceLinkContentInit);
+    constructor(init: McpResourceLinkContentInit);
     toJSON(): Record<string, unknown>;
 }
 
-/** Initializer for `ResourceContent`. `blob` is base64-encoded automatically for Buffer/ArrayBuffer values. */
-export interface ResourceContentInit {
+/** Initializer for `McpResourceContent`. `blob` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface McpResourceContentInit {
     resource: {
         uri: string;
         mimeType?: string;
@@ -315,10 +315,10 @@ export interface ResourceContentInit {
 }
 
 /** An embedded-resource content block in an MCP tool response. */
-export declare class ResourceContent extends McpContentBlock {
+export declare class McpResourceContent extends McpContentBlock {
     readonly type: 'resource';
-    readonly resource: ResourceContentInit['resource'];
-    constructor(init: ResourceContentInit);
+    readonly resource: McpResourceContentInit['resource'];
+    constructor(init: McpResourceContentInit);
     toJSON(): Record<string, unknown>;
 }
 
@@ -337,8 +337,8 @@ export interface McpToolResponseInit {
  * ```typescript
  * return new McpToolResponse({
  *   content: [
- *     new TextContent('Here is the image'),
- *     new ImageContent({ data: base64Data, mimeType: 'image/png' })
+ *     new McpTextContent('Here is the image'),
+ *     new McpImageContent({ data: base64Data, mimeType: 'image/png' })
  *   ],
  *   structuredContent: { imageId: 'logo', format: 'png' }
  * });

--- a/types/mcpTool.d.ts
+++ b/types/mcpTool.d.ts
@@ -152,75 +152,123 @@ export type Arg = Omit<McpToolProperty, 'propertyName'>;
 export type Args = Record<string, Arg>;
 
 /**
- * A text content block in an MCP tool response.
- * Equivalent to .NET's TextContentBlock.
+ * Abstract base class for MCP tool response content blocks.
+ *
+ * The Azure Functions library discriminates content blocks from plain user values using
+ * `instanceof McpContentBlock`, so only instances of the built-in subclasses
+ * (`TextContent`, `ImageContent`, `AudioContent`, `ResourceLinkContent`, `ResourceContent`)
+ * — or a custom subclass that extends this class — will be treated as content blocks.
+ *
+ * Plain object literals like `{ type: 'text', text: '...' }` are **not** treated as
+ * content blocks and will be serialized as JSON text instead.
  */
-export interface TextContentBlock {
-    type: 'text';
-    text: string;
+export declare abstract class McpContentBlock {
+    abstract readonly type: string;
+    abstract toJSON(): Record<string, unknown>;
 }
 
-/**
- * An image content block in an MCP tool response.
- * Equivalent to .NET's ImageContentBlock.
- * `data` must be base64-encoded. The library automatically encodes Buffer/ArrayBuffer values.
- */
-export interface ImageContentBlock {
-    type: 'image';
+/** A text content block in an MCP tool response. */
+export declare class TextContent extends McpContentBlock {
+    readonly type: 'text';
+    readonly text: string;
+    constructor(text: string);
+    toJSON(): Record<string, unknown>;
+}
+
+/** Initializer for `ImageContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface ImageContentInit {
     data: string | Buffer | ArrayBuffer;
     mimeType?: string;
 }
 
-/**
- * An audio content block in an MCP tool response.
- */
-export interface AudioContentBlock {
-    type: 'audio';
+/** An image content block in an MCP tool response. */
+export declare class ImageContent extends McpContentBlock {
+    readonly type: 'image';
+    readonly data: string | Buffer | ArrayBuffer;
+    readonly mimeType?: string;
+    constructor(init: ImageContentInit);
+    toJSON(): Record<string, unknown>;
+}
+
+/** Initializer for `AudioContent`. `data` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface AudioContentInit {
     data: string | Buffer | ArrayBuffer;
     mimeType?: string;
 }
 
-/**
- * A resource-link content block in an MCP tool response.
- */
-export interface ResourceLinkContentBlock {
-    type: 'resource_link';
+/** An audio content block in an MCP tool response. */
+export declare class AudioContent extends McpContentBlock {
+    readonly type: 'audio';
+    readonly data: string | Buffer | ArrayBuffer;
+    readonly mimeType?: string;
+    constructor(init: AudioContentInit);
+    toJSON(): Record<string, unknown>;
+}
+
+/** Initializer for `ResourceLinkContent`. */
+export interface ResourceLinkContentInit {
     uri: string;
     name?: string;
     description?: string;
     mimeType?: string;
 }
 
-/**
- * Union of all known content block types for an MCP tool response.
- * Equivalent to .NET's ContentBlock base class.
- */
-export type McpContentBlock =
-    | TextContentBlock
-    | ImageContentBlock
-    | AudioContentBlock
-    | ResourceLinkContentBlock
-    | Record<string, unknown>;
+/** A resource-link content block in an MCP tool response. */
+export declare class ResourceLinkContent extends McpContentBlock {
+    readonly type: 'resource_link';
+    readonly uri: string;
+    readonly name?: string;
+    readonly description?: string;
+    readonly mimeType?: string;
+    constructor(init: ResourceLinkContentInit);
+    toJSON(): Record<string, unknown>;
+}
 
-/**
- * Full call-tool result with explicit content blocks and optional structured content.
- * Use this when you need manual control over both content and structuredContent.
- * Equivalent to constructing a CallToolResult in .NET with explicit blocks.
- *
- * ```typescript
- * return {
- *   content: [
- *     { type: 'text', text: 'Here is the image' },
- *     { type: 'image', data: base64Data, mimeType: 'image/png' }
- *   ],
- *   structuredContent: { imageId: 'logo', format: 'png' }
- * };
- * ```
- */
-export interface CallToolResult {
+/** Initializer for `ResourceContent`. `blob` is base64-encoded automatically for Buffer/ArrayBuffer values. */
+export interface ResourceContentInit {
+    resource: {
+        uri: string;
+        mimeType?: string;
+        text?: string;
+        blob?: string | Buffer | ArrayBuffer;
+    };
+}
+
+/** An embedded-resource content block in an MCP tool response. */
+export declare class ResourceContent extends McpContentBlock {
+    readonly type: 'resource';
+    readonly resource: ResourceContentInit['resource'];
+    constructor(init: ResourceContentInit);
+    toJSON(): Record<string, unknown>;
+}
+
+/** Initializer for `McpToolResponse`. */
+export interface McpToolResponseInit {
     content: McpContentBlock[];
     structuredContent?: unknown;
     isError?: boolean;
+}
+
+/**
+ * Full MCP tool response with explicit content blocks and optional structured content.
+ * Return an instance of this class from a tool handler when you need full control over
+ * both the content array and `structuredContent`.
+ *
+ * ```typescript
+ * return new McpToolResponse({
+ *   content: [
+ *     new TextContent('Here is the image'),
+ *     new ImageContent({ data: base64Data, mimeType: 'image/png' })
+ *   ],
+ *   structuredContent: { imageId: 'logo', format: 'png' }
+ * });
+ * ```
+ */
+export declare class McpToolResponse {
+    readonly content: McpContentBlock[];
+    readonly structuredContent?: unknown;
+    readonly isError?: boolean;
+    constructor(init: McpToolResponseInit);
 }
 
 /**


### PR DESCRIPTION
Unambiguous detection via instanceof,  no more structural guessing. [{ content: [...], status: "ok" }](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or [{ type: 'report', content: '...' }](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) are definitively plain user values, eliminating all four false-positive paths you identified.


Zero runtime cost vs. the SDK — no @modelcontextprotocol/sdk or Zod dependency, so cold start on Azure Functions workers stays unaffected. The classes are small and tree-shakeable.

Self-normalizing payloads — each block's [toJSON()](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) handles Buffer/ArrayBuffer → base64 and omits undefined fields, so the converter no longer has to walk unknown object shapes looking for [data](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fields to encode.

Discoverable, typed API — IntelliSense surfaces [TextContent](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [ImageContent](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [McpToolResponse](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), etc. with typed constructors. Users can't accidentally produce a malformed block the way they could with raw object literals.

Simpler, smaller converter — the detection chain collapsed from five overlapping predicates plus a fallback to three instanceof checks, making the code easier to audit and less likely to regress.


Example would be 




```

export class McpToolResponse {
    readonly content: McpContentBlock[];
    readonly structuredContent?: unknown;
    readonly isError?: boolean;
}

```


usage would be instead of 




```
export async function getImageWithMetadata(
    _toolArguments: unknown,
    _context: InvocationContext
): Promise<CallToolResult> {
    const metadata = {
        imageId: 'logo',
        format: 'png',
        tags: ['functions', 'azure', 'serverless'],
    };

    const content: [TextContentBlock, ImageContentBlock] = [
        { type: 'text', text: JSON.stringify(metadata) },
        { type: 'image', data: base64ImageData, mimeType: 'image/png' },
    ];

    return {
        content,
        structuredContent: metadata,
    };
}
```

The contract would be cleaner


```
export async function getImageWithMetadata(
    _toolArguments: unknown,
    _context: InvocationContext
): Promise<McpToolResponse> {
    const metadata = {
        imageId: 'logo',
        format: 'png',
        tags: ['functions', 'azure', 'serverless'],
    };

    return new McpToolResponse({
        content: [
            new TextContent(JSON.stringify(metadata)),
            new ImageContent({ data: base64ImageData, mimeType: 'image/png' }),
        ],
        structuredContent: metadata,
    });
}
```


