### PR TITLE
Add auto-label workflow for area:nodejs-functions

### DIFF
--- a/.github/workflows/auto-label-area.yml
+++ b/.github/workflows/auto-label-area.yml
@@ -1,0 +1,26 @@
+name: Auto-label area
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-area-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add area label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const AREA_LABEL = "area:nodejs-functions";
+            const labels = context.payload.issue.labels.map(l => l.name);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: [AREA_LABEL],
+              });
+            }


### PR DESCRIPTION
Automatically adds `area:nodejs-functions` label to all new issues in this repo.

This supports the cross-repo Buc-ees Project V2 board (#539) views, which filter by area labels to provide per-language panes.