### PR TITLE
Add MCP Prompt trigger support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.13.0",
+    "version": "4.14.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.13.0",
+            "version": "4.14.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.13.0",
+    "version": "4.14.0",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/InvocationModel.ts
+++ b/src/InvocationModel.ts
@@ -25,8 +25,9 @@ import { AzFuncSystemError } from './errors';
 import { waitForProxyRequest } from './http/httpProxy';
 import { createStreamRequest } from './http/HttpRequest';
 import { InvocationContext } from './InvocationContext';
+import { PromptInvocationContext } from './mcp/PromptInvocationContext';
 import { enableHttpStream } from './setup';
-import { isHttpTrigger, isMcpToolTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
+import { isHttpTrigger, isMcpPromptTrigger, isMcpToolTrigger, isTimerTrigger, isTrigger } from './utils/isTrigger';
 import { isDefined, nonNullProp, nonNullValue } from './utils/nonNull';
 
 export class InvocationModel implements coreTypes.InvocationModel {
@@ -86,6 +87,10 @@ export class InvocationModel implements coreTypes.InvocationModel {
 
                 if (isTimerTrigger(bindingType)) {
                     input = toCamelCaseValue(input);
+                }
+
+                if (isMcpPromptTrigger(bindingType)) {
+                    input = new PromptInvocationContext(input);
                 }
 
                 if (isTrigger(bindingType)) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
     HttpHandler,
     HttpMethod,
     HttpMethodFunctionOptions,
+    McpPromptFunctionOptions,
     McpResourceFunctionOptions,
     McpToolFunctionOptions,
     MySqlFunctionOptions,
@@ -167,6 +168,17 @@ export function mcpTool(name: string, options: McpToolFunctionOptions): void {
  */
 export function mcpResource(name: string, options: McpResourceFunctionOptions): void {
     generic(name, convertToGenericOptions(options, trigger.mcpResource));
+}
+
+/**
+ * Registers an MCP Prompt function in your app.
+ * The handler receives a structured `PromptInvocationContext` describing the prompt invocation.
+ *
+ * @param name - The name of the function. This must be unique within your app and is primarily used for tracking purposes.
+ * @param options - Configuration options for the MCP Prompt function, including the handler, prompt name, and arguments.
+ */
+export function mcpPrompt(name: string, options: McpPromptFunctionOptions): void {
+    generic(name, convertToGenericOptions(options, trigger.mcpPrompt));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.13.0';
+export const version = '4.14.0';
 
 export const returnBindingKey = '$return';

--- a/src/converters/toMcpPromptTriggerOptionsToRpc.ts
+++ b/src/converters/toMcpPromptTriggerOptionsToRpc.ts
@@ -1,7 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { McpPromptArgument, McpPromptTriggerOptions, McpPromptTriggerOptionsToRpc } from '../../types/mcpPrompt';
+import {
+    McpPromptArgument,
+    McpPromptArguments,
+    McpPromptTriggerOptions,
+    McpPromptTriggerOptionsToRpc,
+} from '../../types/mcpPrompt';
+import { McpPromptArgumentBuilder } from '../mcp/McpPromptArgumentBuilder';
 
 /**
  * Converts an {@link McpPromptTriggerOptions} object to the wire-format
@@ -52,19 +58,34 @@ export function convertToMcpPromptTriggerOptionsToRpc(options: McpPromptTriggerO
     return result;
 }
 
-function serializePromptArguments(args: McpPromptArgument[] | undefined): string {
-    if (!args || args.length === 0) {
+function serializePromptArguments(args: McpPromptArguments | undefined): string {
+    if (!args) {
         return '[]';
     }
 
-    const normalized = args.map((arg) => {
-        if (!arg.name || typeof arg.name !== 'string' || arg.name.trim() === '') {
+    const list: McpPromptArgument[] = Array.isArray(args)
+        ? args
+        : Object.entries(args).map(([name, builder]) => {
+              if (!(builder instanceof McpPromptArgumentBuilder)) {
+                  throw new Error(
+                      'MCP Prompt trigger "promptArguments" record values must be created with `promptArg.describe(...)`.'
+                  );
+              }
+              return builder.toPromptArgument(name);
+          });
+
+    if (list.length === 0) {
+        return '[]';
+    }
+
+    const normalized = list.map((a) => {
+        if (!a.name || typeof a.name !== 'string' || a.name.trim() === '') {
             throw new Error('MCP Prompt trigger "promptArguments" entries require a non-empty "name".');
         }
         return {
-            name: arg.name,
-            description: arg.description ?? null,
-            required: arg.required === true,
+            name: a.name,
+            description: a.description ?? null,
+            required: a.required === true,
         };
     });
 

--- a/src/converters/toMcpPromptTriggerOptionsToRpc.ts
+++ b/src/converters/toMcpPromptTriggerOptionsToRpc.ts
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { McpPromptArgument, McpPromptTriggerOptions, McpPromptTriggerOptionsToRpc } from '../../types/mcpPrompt';
+
+/**
+ * Converts an {@link McpPromptTriggerOptions} object to the wire-format
+ * {@link McpPromptTriggerOptionsToRpc} the Functions host expects.
+ *
+ * - `promptName` is required.
+ * - `promptArguments` is serialized to a compact JSON string (always present on the wire).
+ * - `metadata` and `icons` are validated as JSON strings when supplied.
+ */
+export function convertToMcpPromptTriggerOptionsToRpc(options: McpPromptTriggerOptions): McpPromptTriggerOptionsToRpc {
+    if (!options.promptName || typeof options.promptName !== 'string' || options.promptName.trim() === '') {
+        throw new Error('MCP Prompt trigger requires a valid "promptName" property.');
+    }
+
+    const promptArgumentsJson = serializePromptArguments(options.promptArguments);
+
+    const result: McpPromptTriggerOptionsToRpc = {
+        promptName: options.promptName,
+        promptArguments: promptArgumentsJson,
+    };
+
+    if (options.title !== undefined) {
+        result.title = options.title;
+    }
+
+    if (options.description !== undefined) {
+        result.description = options.description;
+    }
+
+    if (options.metadata !== undefined && typeof options.metadata === 'string' && options.metadata.trim() !== '') {
+        try {
+            JSON.parse(options.metadata);
+        } catch {
+            throw new Error('MCP Prompt trigger "metadata" must be a valid JSON string.');
+        }
+        result.metadata = options.metadata;
+    }
+
+    if (options.icons !== undefined && typeof options.icons === 'string' && options.icons.trim() !== '') {
+        try {
+            JSON.parse(options.icons);
+        } catch {
+            throw new Error('MCP Prompt trigger "icons" must be a valid JSON string.');
+        }
+        result.icons = options.icons;
+    }
+
+    return result;
+}
+
+function serializePromptArguments(args: McpPromptArgument[] | undefined): string {
+    if (!args || args.length === 0) {
+        return '[]';
+    }
+
+    const normalized = args.map((arg) => {
+        if (!arg.name || typeof arg.name !== 'string' || arg.name.trim() === '') {
+            throw new Error('MCP Prompt trigger "promptArguments" entries require a non-empty "name".');
+        }
+        return {
+            name: arg.name,
+            description: arg.description ?? null,
+            required: arg.required === true,
+        };
+    });
+
+    return JSON.stringify(normalized);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
     McpTextContent,
     McpToolResponse,
 } from './mcp/McpToolResponse';
+export { PromptInvocationContext } from './mcp/PromptInvocationContext';
 export * as output from './output';
 export * as trigger from './trigger';
 export { Disposable } from './utils/Disposable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { HttpRequest } from './http/HttpRequest';
 export { HttpResponse } from './http/HttpResponse';
 export * as input from './input';
 export { InvocationContext } from './InvocationContext';
+export { promptArg } from './mcp/McpPromptArgumentBuilder';
 export {
     McpAudioContent,
     McpContentBlock,

--- a/src/mcp/McpPromptArgumentBuilder.ts
+++ b/src/mcp/McpPromptArgumentBuilder.ts
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { McpPromptArgument } from '../../types/mcpPrompt';
+
+/**
+ * Fluent builder for declaring MCP prompt arguments.
+ *
+ * Used in the record-style `promptArguments` map where the key is the argument name.
+ *
+ * @example
+ * ```ts
+ * promptArguments: {
+ *     function_name: promptArg.describe('The function to document.').isRequired(),
+ *     style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
+ * }
+ * ```
+ *
+ * @remarks
+ * By default, arguments are **not required**. Call `.isRequired()` to mark them as required.
+ */
+export class McpPromptArgumentBuilder {
+    private _description?: string;
+    private _required = false;
+
+    /**
+     * Set the argument's description shown to MCP clients.
+     */
+    describe(description: string): this {
+        this._description = description;
+        return this;
+    }
+
+    /**
+     * Mark the argument as required. By default arguments are optional.
+     */
+    isRequired(): this {
+        this._required = true;
+        return this;
+    }
+
+    /**
+     * @internal Resolve to the wire-facing {@link McpPromptArgument} shape using the supplied name.
+     */
+    toPromptArgument(name: string): McpPromptArgument {
+        return {
+            name,
+            description: this._description,
+            required: this._required,
+        };
+    }
+}
+
+/**
+ * Factory for creating MCP **prompt** argument builders.
+ *
+ * Kept separate from the tool-property `arg` helper because prompt arguments
+ * are untyped (name + description + required only) and should not be mixed
+ * with typed tool property builders (`arg.string()`, `arg.number()`, ...).
+ *
+ * @example
+ * ```ts
+ * import { promptArg } from '@azure/functions';
+ *
+ * app.mcpPromptTrigger({
+ *     promptName: 'generate_docs',
+ *     promptArguments: {
+ *         function_name: promptArg.describe('The function to document.').isRequired(),
+ *         style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
+ *     },
+ *     handler: async (ctx) => { ... },
+ * });
+ * ```
+ */
+export const promptArg = {
+    /**
+     * Start building a prompt argument with a description.
+     */
+    describe(description: string): McpPromptArgumentBuilder {
+        return new McpPromptArgumentBuilder().describe(description);
+    },
+};

--- a/src/mcp/PromptInvocationContext.ts
+++ b/src/mcp/PromptInvocationContext.ts
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Structured context object passed to MCP prompt handlers.
+ *
+ * Provides typed access to the invoked prompt's name, arguments (all values are strings),
+ * optional session id, and optional transport metadata. Can be constructed either from
+ * a parsed object or from a JSON string — both shapes are emitted by the MCP extension
+ * depending on trigger metadata wiring.
+ */
+export class PromptInvocationContext {
+    readonly name: string;
+    readonly arguments: Record<string, string>;
+    readonly sessionId: string | undefined;
+    readonly transport: Record<string, unknown> | undefined;
+
+    constructor(data: unknown) {
+        let obj: Record<string, unknown> = {};
+
+        if (typeof data === 'string') {
+            try {
+                const parsed: unknown = JSON.parse(data);
+                if (parsed && typeof parsed === 'object') {
+                    obj = parsed as Record<string, unknown>;
+                }
+            } catch {
+                obj = {};
+            }
+        } else if (data && typeof data === 'object') {
+            obj = data as Record<string, unknown>;
+        }
+
+        this.name = typeof obj.name === 'string' ? obj.name : '';
+
+        const args = obj.arguments;
+        if (args && typeof args === 'object' && !Array.isArray(args)) {
+            const out: Record<string, string> = {};
+            for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+                out[k] = typeof v === 'string' ? v : v === undefined || v === null ? '' : String(v);
+            }
+            this.arguments = out;
+        } else {
+            this.arguments = {};
+        }
+
+        // Accept both `sessionId` and Python-style `sessionid` from the host payload.
+        const sid = obj.sessionId ?? obj.sessionid;
+        this.sessionId = typeof sid === 'string' ? sid : undefined;
+
+        const transport = obj.transport;
+        this.transport =
+            transport && typeof transport === 'object' && !Array.isArray(transport)
+                ? (transport as Record<string, unknown>)
+                : undefined;
+    }
+}

--- a/src/mcp/PromptInvocationContext.ts
+++ b/src/mcp/PromptInvocationContext.ts
@@ -44,7 +44,7 @@ export class PromptInvocationContext {
             this.arguments = {};
         }
 
-        // Accept both `sessionId` and Python-style `sessionid` from the host payload.
+        // Accept both `sessionId` and `sessionid` casings from the host payload.
         const sid = obj.sessionId ?? obj.sessionid;
         this.sessionId = typeof sid === 'string' ? sid : undefined;
 

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -12,6 +12,8 @@ import {
     GenericTriggerOptions,
     HttpTrigger,
     HttpTriggerOptions,
+    McpPromptTrigger,
+    McpPromptTriggerOptions,
     McpResourceTrigger,
     McpResourceTriggerOptions,
     McpToolTrigger,
@@ -36,6 +38,7 @@ import {
     WebPubSubTriggerOptions,
 } from '@azure/functions';
 import { addBindingName } from './addBindingName';
+import { convertToMcpPromptTriggerOptionsToRpc } from './converters/toMcpPromptTriggerOptionsToRpc';
 import { convertToMcpResourceTriggerOptionsToRpc } from './converters/toMcpResourceTriggerOptionsToRpc';
 import { converToMcpToolTriggerOptionsToRpc } from './converters/toMcpToolTriggerOptionsToRpc';
 
@@ -158,6 +161,21 @@ export function mcpResource(options: McpResourceTriggerOptions): McpResourceTrig
     return addTriggerBindingName({
         ...convertToMcpResourceTriggerOptionsToRpc(options),
         type: 'mcpResourceTrigger',
+    });
+}
+
+/**
+ * Creates an MCP Prompt trigger configuration.
+ * This function is used to define an MCP Prompt trigger for an Azure Function.
+ * MCP Prompts are templates that MCP clients can request by name, optionally supplying arguments.
+ *
+ * @param options - The configuration options for the MCP Prompt trigger, including prompt-specific metadata.
+ * @returns An MCP Prompt trigger object with the specified configuration.
+ */
+export function mcpPrompt(options: McpPromptTriggerOptions): McpPromptTrigger {
+    return addTriggerBindingName({
+        ...convertToMcpPromptTriggerOptionsToRpc(options),
+        type: 'mcpPromptTrigger',
     });
 }
 

--- a/src/utils/isTrigger.ts
+++ b/src/utils/isTrigger.ts
@@ -16,3 +16,7 @@ export function isTimerTrigger(typeName: string | undefined | null): boolean {
 export function isMcpToolTrigger(typeName: string | undefined | null): boolean {
     return typeName?.toLowerCase() === 'mcptooltrigger';
 }
+
+export function isMcpPromptTrigger(typeName: string | undefined | null): boolean {
+    return typeName?.toLowerCase() === 'mcpprompttrigger';
+}

--- a/test/InvocationModel.test.ts
+++ b/test/InvocationModel.test.ts
@@ -4,7 +4,7 @@
 import 'mocha';
 import { RpcLogCategory, RpcLogLevel } from '@azure/functions-core';
 import { expect } from 'chai';
-import { McpImageContent, InvocationContext, McpContent } from '../src';
+import { InvocationContext, McpContent, McpImageContent } from '../src';
 import { InvocationModel } from '../src/InvocationModel';
 
 function testLog(_level: RpcLogLevel, _category: RpcLogCategory, message: string) {

--- a/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { convertToMcpPromptTriggerOptionsToRpc } from '../../src/converters/toMcpPromptTriggerOptionsToRpc';
+import { McpPromptTriggerOptions } from '../../types/mcpPrompt';
+
+describe('convertToMcpPromptTriggerOptionsToRpc', () => {
+    describe('required properties validation', () => {
+        it('throws when promptName is missing', () => {
+            expect(() => 'MCP Prompt trigger requires a valid "promptName" property.').to.throw(
+                
+            
+        });
+
+        it('throws when promptName is empty', () => {
+            expect(() => 'MCP Prompt trigger requires a valid "promptName" property.').to.throw(
+                
+            
+        });
+    });
+
+    describe('promptArguments serialization', () => {
+        it('emits "[]" when no arguments are supplied', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p' });
+            expect(result.promptArguments).to.equal('[]');
+        });
+
+        it('emits "[]" when arguments array is empty', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                promptArguments: [],
+            });
+            expect(result.promptArguments).to.equal('[]');
+        });
+
+        it('serializes arguments with defaults (description: null, required: false)', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                promptArguments: [{ name: 'text' }],
+            });
+            const parsed = JSON.parse(result.promptArguments!);
+            expect(parsed).to.deep.equal([{ name: 'text', description: null, required: false }]);
+        });
+
+        it('serializes multiple arguments with full metadata', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'code_review',
+                promptArguments: [
+                    { name: 'code', description: 'Code to review', required: true },
+                    { name: 'language', description: 'Programming language', required: false },
+                ],
+            });
+            const parsed = JSON.parse(result.promptArguments!);
+            expect(parsed).to.deep.equal([
+                { name: 'code', description: 'Code to review', required: true },
+                { name: 'language', description: 'Programming language', required: false },
+            ]);
+        });
+
+        it('throws when an argument has no name', () => {
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({
+                    promptName: 'p',
+                    promptArguments: [{ name: '' }],
+                })
+            ).to.throw('MCP Prompt trigger "promptArguments" entries require a non-empty "name".');
+        });
+    });
+
+    describe('optional fields', () => {
+        it('passes through title, description', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                title: 'Prompt Title',
+                description: 'A prompt',
+            });
+            expect(result.title).to.equal('Prompt Title');
+            expect(result.description).to.equal('A prompt');
+        });
+
+        it('validates metadata is a JSON string', () => {
+            expect(() => 'MCP Prompt trigger "metadata" must be a valid JSON string.').to.throw(
+                
+            
+        });
+
+        it('accepts valid metadata JSON', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                metadata: '{"version":"1.0"}',
+            });
+            expect(result.metadata).to.equal('{"version":"1.0"}');
+        });
+
+        it('validates icons is a JSON string', () => {
+            expect(() => 'MCP Prompt trigger "icons" must be a valid JSON string.').to.throw(
+                
+            
+        });
+
+        it('accepts valid icons JSON', () => {
+            const icons = '[{"name":"code","url":"https://example.com/icon.png"}]';
+            const result = convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons });
+            expect(result.icons).to.equal(icons);
+        });
+
+        it('omits empty/whitespace-only metadata and icons', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                metadata: '   ',
+                icons: '',
+            });
+            expect(result.metadata).to.equal(undefined);
+            expect(result.icons).to.equal(undefined);
+        });
+    });
+});

--- a/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
@@ -9,15 +9,15 @@ import { McpPromptTriggerOptions } from '../../types/mcpPrompt';
 describe('convertToMcpPromptTriggerOptionsToRpc', () => {
     describe('required properties validation', () => {
         it('throws when promptName is missing', () => {
-            expect(() => 'MCP Prompt trigger requires a valid "promptName" property.').to.throw(
-                
-            
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({} as McpPromptTriggerOptions)
+            ).to.throw('MCP Prompt trigger requires a valid "promptName" property.');
         });
 
         it('throws when promptName is empty', () => {
-            expect(() => 'MCP Prompt trigger requires a valid "promptName" property.').to.throw(
-                
-            
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({ promptName: '   ' })
+            ).to.throw('MCP Prompt trigger requires a valid "promptName" property.');
         });
     });
 
@@ -81,9 +81,9 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
         });
 
         it('validates metadata is a JSON string', () => {
-            expect(() => 'MCP Prompt trigger "metadata" must be a valid JSON string.').to.throw(
-                
-            
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', metadata: '{ not json' })
+            ).to.throw('MCP Prompt trigger "metadata" must be a valid JSON string.');
         });
 
         it('accepts valid metadata JSON', () => {
@@ -95,9 +95,9 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
         });
 
         it('validates icons is a JSON string', () => {
-            expect(() => 'MCP Prompt trigger "icons" must be a valid JSON string.').to.throw(
-                
-            
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons: 'not json' })
+            ).to.throw('MCP Prompt trigger "icons" must be a valid JSON string.');
         });
 
         it('accepts valid icons JSON', () => {
@@ -105,7 +105,6 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons });
             expect(result.icons).to.equal(icons);
         });
-
         it('omits empty/whitespace-only metadata and icons', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'p',

--- a/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
@@ -28,48 +28,41 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
             expect(result.promptArguments).to.equal('[]');
         });
 
-        it('emits "[]" when arguments array is empty', () => {
+        it('emits "[]" for an empty fluent record', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'p',
-                promptArguments: [],
+                promptArguments: {},
             });
             expect(result.promptArguments).to.equal('[]');
         });
 
-        it('serializes arguments with defaults (description: null, required: false)', () => {
+        it('serializes a single fluent argument with defaults (description set, required: false)', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'p',
-                promptArguments: [{ name: 'text' }],
+                promptArguments: {
+                    text: promptArg.describe('Input text'),
+                },
             });
-            const parsed = JSON.parse(result.promptArguments!);
-            expect(parsed).to.deep.equal([{ name: 'text', description: null, required: false }]);
+            const parsed = JSON.parse(result.promptArguments ?? '');
+            expect(parsed).to.deep.equal([{ name: 'text', description: 'Input text', required: false }]);
         });
 
-        it('serializes multiple arguments with full metadata', () => {
+        it('serializes multiple fluent arguments with mixed required flags', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'code_review',
-                promptArguments: [
-                    { name: 'code', description: 'Code to review', required: true },
-                    { name: 'language', description: 'Programming language', required: false },
-                ],
+                promptArguments: {
+                    code: promptArg.describe('Code to review').isRequired(),
+                    language: promptArg.describe('Programming language'),
+                },
             });
-            const parsed = JSON.parse(result.promptArguments!);
+            const parsed = JSON.parse(result.promptArguments ?? '');
             expect(parsed).to.deep.equal([
                 { name: 'code', description: 'Code to review', required: true },
                 { name: 'language', description: 'Programming language', required: false },
             ]);
         });
 
-        it('throws when an argument has no name', () => {
-            expect(() =>
-                convertToMcpPromptTriggerOptionsToRpc({
-                    promptName: 'p',
-                    promptArguments: [{ name: '' }],
-                })
-            ).to.throw('MCP Prompt trigger "promptArguments" entries require a non-empty "name".');
-        });
-
-        it('accepts the fluent record form built with promptArg.describe(...)', () => {
+        it('accepts the fluent record form matching the generate_docs sample', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'generate_docs',
                 promptArguments: {
@@ -77,7 +70,7 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
                     style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
                 },
             });
-            const parsed = JSON.parse(result.promptArguments!);
+            const parsed = JSON.parse(result.promptArguments ?? '');
             expect(parsed).to.deep.equal([
                 { name: 'function_name', description: 'The function to document.', required: true },
                 {
@@ -86,14 +79,6 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
                     required: false,
                 },
             ]);
-        });
-
-        it('emits "[]" for an empty record form', () => {
-            const result = convertToMcpPromptTriggerOptionsToRpc({
-                promptName: 'p',
-                promptArguments: {},
-            });
-            expect(result.promptArguments).to.equal('[]');
         });
 
         it('throws when a record value is not built with promptArg.describe(...)', () => {
@@ -121,9 +106,9 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
         });
 
         it('validates metadata is a JSON string', () => {
-            expect(() => 'MCP Prompt trigger "metadata" must be a valid JSON string.').to.throw(
-                
-            
+            expect(() => convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', metadata: '{ not json' })).to.throw(
+                'MCP Prompt trigger "metadata" must be a valid JSON string.'
+            );
         });
 
         it('accepts valid metadata JSON', () => {

--- a/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
+++ b/test/converters/toMcpPromptTriggerOptionsToRpc.test.ts
@@ -4,20 +4,21 @@
 import 'mocha';
 import { expect } from 'chai';
 import { convertToMcpPromptTriggerOptionsToRpc } from '../../src/converters/toMcpPromptTriggerOptionsToRpc';
+import { promptArg } from '../../src/mcp/McpPromptArgumentBuilder';
 import { McpPromptTriggerOptions } from '../../types/mcpPrompt';
 
 describe('convertToMcpPromptTriggerOptionsToRpc', () => {
     describe('required properties validation', () => {
         it('throws when promptName is missing', () => {
-            expect(() =>
-                convertToMcpPromptTriggerOptionsToRpc({} as McpPromptTriggerOptions)
-            ).to.throw('MCP Prompt trigger requires a valid "promptName" property.');
+            expect(() => convertToMcpPromptTriggerOptionsToRpc({} as McpPromptTriggerOptions)).to.throw(
+                'MCP Prompt trigger requires a valid "promptName" property.'
+            );
         });
 
         it('throws when promptName is empty', () => {
-            expect(() =>
-                convertToMcpPromptTriggerOptionsToRpc({ promptName: '   ' })
-            ).to.throw('MCP Prompt trigger requires a valid "promptName" property.');
+            expect(() => convertToMcpPromptTriggerOptionsToRpc({ promptName: '   ' })).to.throw(
+                'MCP Prompt trigger requires a valid "promptName" property.'
+            );
         });
     });
 
@@ -67,6 +68,45 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
                 })
             ).to.throw('MCP Prompt trigger "promptArguments" entries require a non-empty "name".');
         });
+
+        it('accepts the fluent record form built with promptArg.describe(...)', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'generate_docs',
+                promptArguments: {
+                    function_name: promptArg.describe('The function to document.').isRequired(),
+                    style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
+                },
+            });
+            const parsed = JSON.parse(result.promptArguments!);
+            expect(parsed).to.deep.equal([
+                { name: 'function_name', description: 'The function to document.', required: true },
+                {
+                    name: 'style',
+                    description: "Documentation style (e.g., 'concise', 'verbose').",
+                    required: false,
+                },
+            ]);
+        });
+
+        it('emits "[]" for an empty record form', () => {
+            const result = convertToMcpPromptTriggerOptionsToRpc({
+                promptName: 'p',
+                promptArguments: {},
+            });
+            expect(result.promptArguments).to.equal('[]');
+        });
+
+        it('throws when a record value is not built with promptArg.describe(...)', () => {
+            expect(() =>
+                convertToMcpPromptTriggerOptionsToRpc({
+                    promptName: 'p',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    promptArguments: { foo: { description: 'x' } as any },
+                })
+            ).to.throw(
+                'MCP Prompt trigger "promptArguments" record values must be created with `promptArg.describe(...)`.'
+            );
+        });
     });
 
     describe('optional fields', () => {
@@ -81,9 +121,9 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
         });
 
         it('validates metadata is a JSON string', () => {
-            expect(() =>
-                convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', metadata: '{ not json' })
-            ).to.throw('MCP Prompt trigger "metadata" must be a valid JSON string.');
+            expect(() => 'MCP Prompt trigger "metadata" must be a valid JSON string.').to.throw(
+                
+            
         });
 
         it('accepts valid metadata JSON', () => {
@@ -95,9 +135,9 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
         });
 
         it('validates icons is a JSON string', () => {
-            expect(() =>
-                convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons: 'not json' })
-            ).to.throw('MCP Prompt trigger "icons" must be a valid JSON string.');
+            expect(() => convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons: 'not json' })).to.throw(
+                'MCP Prompt trigger "icons" must be a valid JSON string.'
+            );
         });
 
         it('accepts valid icons JSON', () => {
@@ -105,6 +145,7 @@ describe('convertToMcpPromptTriggerOptionsToRpc', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({ promptName: 'p', icons });
             expect(result.icons).to.equal(icons);
         });
+
         it('omits empty/whitespace-only metadata and icons', () => {
             const result = convertToMcpPromptTriggerOptionsToRpc({
                 promptName: 'p',

--- a/test/converters/toMcpToolResult.test.ts
+++ b/test/converters/toMcpToolResult.test.ts
@@ -6,12 +6,12 @@ import { expect } from 'chai';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
 import {
     McpAudioContent,
-    McpImageContent,
     McpContentBlock,
-    McpToolResponse,
+    McpImageContent,
     McpResourceContent,
     McpResourceLinkContent,
     McpTextContent,
+    McpToolResponse,
 } from '../../src/mcp/McpToolResponse';
 import { McpContent } from '../../src/utils/mcpContentMarker';
 
@@ -192,9 +192,7 @@ describe('toMcpToolResult', () => {
     });
 
     it('serializes a McpResourceContent block with only text (omits blob and mimeType)', () => {
-        const result = toMcpToolResult(
-            new McpResourceContent({ resource: { uri: 'file:///a.txt', text: 'hello' } })
-        );
+        const result = toMcpToolResult(new McpResourceContent({ resource: { uri: 'file:///a.txt', text: 'hello' } }));
         const content = JSON.parse(result?.content || '{}') as { resource: Record<string, unknown> };
         expect(content.resource).to.deep.equal({ uri: 'file:///a.txt', text: 'hello' });
         expect(content.resource).to.not.have.property('blob');

--- a/test/mcp/McpToolResponse.test.ts
+++ b/test/mcp/McpToolResponse.test.ts
@@ -5,12 +5,12 @@ import 'mocha';
 import { expect } from 'chai';
 import {
     McpAudioContent,
-    McpImageContent,
     McpContentBlock,
-    McpToolResponse,
+    McpImageContent,
     McpResourceContent,
     McpResourceLinkContent,
     McpTextContent,
+    McpToolResponse,
 } from '../../src/mcp/McpToolResponse';
 
 describe('MCP content block classes', () => {

--- a/test/mcp/PromptInvocationContext.test.ts
+++ b/test/mcp/PromptInvocationContext.test.ts
@@ -20,9 +20,7 @@ describe('PromptInvocationContext', () => {
     });
 
     it('parses a JSON string payload', () => {
-        const ctx = new PromptInvocationContext(
-            JSON.stringify({ name: 'summarize', arguments: { text: 'hi' } })
-        );
+        const ctx = new PromptInvocationContext(JSON.stringify({ name: 'summarize', arguments: { text: 'hi' } }));
         expect(ctx.name).to.equal('summarize');
         expect(ctx.arguments).to.deep.equal({ text: 'hi' });
         expect(ctx.sessionId).to.equal(undefined);

--- a/test/mcp/PromptInvocationContext.test.ts
+++ b/test/mcp/PromptInvocationContext.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { PromptInvocationContext } from '../../src/mcp/PromptInvocationContext';
+
+describe('PromptInvocationContext', () => {
+    it('parses a full payload object', () => {
+        const ctx = new PromptInvocationContext({
+            name: 'code_review',
+            arguments: { code: 'print("hello")', language: 'python' },
+            sessionId: 'session-123',
+            transport: { name: 'http' },
+        });
+        expect(ctx.name).to.equal('code_review');
+        expect(ctx.arguments).to.deep.equal({ code: 'print("hello")', language: 'python' });
+        expect(ctx.sessionId).to.equal('session-123');
+        expect(ctx.transport).to.deep.equal({ name: 'http' });
+    });
+
+    it('parses a JSON string payload', () => {
+        const ctx = new PromptInvocationContext(ct(ctx.name).to.equal('summarize');expect(ctx.arguments).to.deep.equal({ text: 'hi' });
+        expect(ctx.sessionId).to.equal(undefined);
+        expect(ctx.transport).to.equal(undefined);
+    });
+
+    it('accepts Python-style "sessionid" key', () => {
+        const ctx = new PromptInvocationContext({ name: 'p', sessionid: 'abc' });
+        expect(ctx.sessionId).to.equal('abc');
+    });
+
+    it('returns defaults for empty object', () => {
+        const ctx = new PromptInvocationContext({});
+        expect(ctx.name).to.equal('');
+        expect(ctx.arguments).to.deep.equal({});
+        expect(ctx.sessionId).to.equal(undefined);
+        expect(ctx.transport).to.equal(undefined);
+    });
+
+    it('returns defaults for invalid JSON string', () => {
+        const ctx = new PromptInvocationContext('not json');
+        expect(ctx.name).to.equal('');
+        expect(ctx.arguments).to.deep.equal({});
+    });
+
+    it('coerces non-string argument values to strings', () => {
+        const ctx = new PromptInvocationContext({
+            name: 'p',
+            arguments: { count: 3, flag: true, missing: null },
+        });
+        expect(ctx.arguments).to.deep.equal({ count: '3', flag: 'true', missing: '' });
+    });
+
+    it('ignores non-object arguments field', () => {
+        const ctx = new PromptInvocationContext({ name: 'p', arguments: 'not-an-object' });
+        expect(ctx.arguments).to.deep.equal({});
+    });
+
+    it('ignores non-object transport field', () => {
+        const ctx = new PromptInvocationContext({ name: 'p', transport: 'http' });
+        expect(ctx.transport).to.equal(undefined);
+    });
+
+    it('handles null/undefined input', () => {
+        expect(new PromptInvocationContext(null).name).to.equal('');
+        expect(new PromptInvocationContext(undefined).name).to.equal('');
+    });
+});

--- a/test/mcp/PromptInvocationContext.test.ts
+++ b/test/mcp/PromptInvocationContext.test.ts
@@ -9,12 +9,12 @@ describe('PromptInvocationContext', () => {
     it('parses a full payload object', () => {
         const ctx = new PromptInvocationContext({
             name: 'code_review',
-            arguments: { code: 'print("hello")', language: 'python' },
+            arguments: { code: 'console.log("hello")', language: 'typescript' },
             sessionId: 'session-123',
             transport: { name: 'http' },
         });
         expect(ctx.name).to.equal('code_review');
-        expect(ctx.arguments).to.deep.equal({ code: 'print("hello")', language: 'python' });
+        expect(ctx.arguments).to.deep.equal({ code: 'console.log("hello")', language: 'typescript' });
         expect(ctx.sessionId).to.equal('session-123');
         expect(ctx.transport).to.deep.equal({ name: 'http' });
     });
@@ -25,7 +25,7 @@ describe('PromptInvocationContext', () => {
         expect(ctx.transport).to.equal(undefined);
     });
 
-    it('accepts Python-style "sessionid" key', () => {
+    it('accepts lowercase "sessionid" key', () => {
         const ctx = new PromptInvocationContext({ name: 'p', sessionid: 'abc' });
         expect(ctx.sessionId).to.equal('abc');
     });

--- a/test/mcp/PromptInvocationContext.test.ts
+++ b/test/mcp/PromptInvocationContext.test.ts
@@ -20,7 +20,11 @@ describe('PromptInvocationContext', () => {
     });
 
     it('parses a JSON string payload', () => {
-        const ctx = new PromptInvocationContext(ct(ctx.name).to.equal('summarize');expect(ctx.arguments).to.deep.equal({ text: 'hi' });
+        const ctx = new PromptInvocationContext(
+            JSON.stringify({ name: 'summarize', arguments: { text: 'hi' } })
+        );
+        expect(ctx.name).to.equal('summarize');
+        expect(ctx.arguments).to.deep.equal({ text: 'hi' });
         expect(ctx.sessionId).to.equal(undefined);
         expect(ctx.transport).to.equal(undefined);
     });

--- a/test/mcp/sdkCompat.test.ts
+++ b/test/mcp/sdkCompat.test.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 import 'mocha';
+import type { InvocationContext } from '@azure/functions';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import type { InvocationContext } from '@azure/functions';
 import { toMcpToolResult } from '../../src/converters/toMcpToolResult';
-import { McpToolResponse, McpTextContent } from '../../src/mcp/McpToolResponse';
+import { McpTextContent, McpToolResponse } from '../../src/mcp/McpToolResponse';
 import { __resetMcpSdkWarning } from '../../src/mcp/sdkCompat';
 
 describe('MCP SDK compat', () => {

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -6,6 +6,7 @@ import { EventGridEvent, EventGridFunctionOptions } from './eventGrid';
 import { EventHubFunctionOptions } from './eventHub';
 import { GenericFunctionOptions } from './generic';
 import { HttpFunctionOptions, HttpHandler, HttpMethodFunctionOptions } from './http';
+import { McpPromptFunctionOptions } from './mcpPrompt';
 import { McpResourceFunctionOptions } from './mcpResource';
 import { McpToolFunctionOptions } from './mcpTool';
 import { MySqlFunctionOptions } from './mySql';
@@ -211,5 +212,12 @@ export function mcpTool<T = unknown>(name: string, options: McpToolFunctionOptio
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function mcpResource<T = unknown>(name: string, options: McpResourceFunctionOptions<T>): void;
+
+/**
+ * Registers an MCP Prompt function in your app that will be triggered when an MCP client requests the prompt.
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the prompt, its arguments, and the handler for this function
+ */
+export function mcpPrompt<T = unknown>(name: string, options: McpPromptFunctionOptions<T>): void;
 
 export * as hook from './hooks/registerHook';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,6 +18,7 @@ export * from './http';
 export * as input from './input';
 export * from './InvocationContext';
 export { hasMcpContentMarker, McpContent, shouldCreateStructuredContentMarker } from './mcpContentMarker';
+export * from './mcpPrompt';
 export * from './mcpResource';
 export * from './mcpTool';
 export * from './mySql';

--- a/types/mcpPrompt.d.ts
+++ b/types/mcpPrompt.d.ts
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionOptions, FunctionResult, FunctionTrigger } from './index';
+import { InvocationContext } from './InvocationContext';
+
+/**
+ * A handler function for MCP Prompt triggers.
+ *
+ * @param context - Structured `PromptInvocationContext` describing the prompt invocation.
+ * @param invocationContext - The invocation context for the function.
+ * @returns A result that can be a promise or a synchronous value.
+ */
+export type McpPromptTriggerHandler<T = PromptInvocationContext> = (
+    context: T,
+    invocationContext: InvocationContext
+) => FunctionResult;
+
+/**
+ * Configuration options for an MCP Prompt function.
+ * This includes trigger-specific options and general function options.
+ */
+export interface McpPromptFunctionOptions<T = PromptInvocationContext>
+    extends McpPromptTriggerOptions,
+        Partial<FunctionOptions> {
+    /**
+     * The handler function to execute when the trigger is invoked.
+     */
+    handler: McpPromptTriggerHandler<T>;
+
+    /**
+     * The trigger configuration for the MCP Prompt.
+     */
+    trigger?: McpPromptTrigger;
+}
+
+/**
+ * Describes a single argument accepted by an MCP prompt.
+ */
+export interface McpPromptArgument {
+    /**
+     * The argument name.
+     */
+    name: string;
+
+    /**
+     * Optional description of the argument shown to MCP clients.
+     */
+    description?: string;
+
+    /**
+     * Whether the argument is required. Defaults to `false`.
+     */
+    required?: boolean;
+}
+
+/**
+ * Configuration options for an MCP Prompt trigger.
+ * These options define the behavior and metadata for the trigger.
+ */
+export interface McpPromptTriggerOptions {
+    /**
+     * Unique name of the prompt.
+     */
+    promptName: string;
+
+    /**
+     * Optional list of arguments the prompt accepts.
+     */
+    promptArguments?: McpPromptArgument[];
+
+    /**
+     * Optional human-readable title for display purposes.
+     */
+    title?: string;
+
+    /**
+     * Optional description of the prompt.
+     */
+    description?: string;
+
+    /**
+     * Optional JSON-serialized metadata object.
+     */
+    metadata?: string;
+
+    /**
+     * Optional JSON-serialized array of icon objects.
+     */
+    icons?: string;
+}
+
+/**
+ * The wire-format options sent to the Functions host for an MCP Prompt trigger.
+ * `promptArguments` is serialized to a JSON string as required by the host binding contract.
+ */
+export interface McpPromptTriggerOptionsToRpc {
+    promptName: string;
+    promptArguments?: string;
+    title?: string;
+    description?: string;
+    metadata?: string;
+    icons?: string;
+}
+
+/**
+ * Represents an MCP Prompt trigger, combining base function trigger options
+ * with MCP Prompt-specific trigger options.
+ */
+export type McpPromptTrigger = FunctionTrigger & McpPromptTriggerOptionsToRpc;
+
+/**
+ * Structured context object passed to MCP prompt handlers.
+ *
+ * Provides typed access to the invoked prompt's name, arguments (all values are strings),
+ * optional session id, and optional transport metadata.
+ *
+ * @example
+ * ```ts
+ * app.mcpPrompt('codeReview', {
+ *     promptName: 'code_review',
+ *     promptArguments: [
+ *         { name: 'code', description: 'The code to review', required: true },
+ *         { name: 'language', description: 'Programming language' }
+ *     ],
+ *     handler: async (ctx: PromptInvocationContext) => {
+ *         const code = ctx.arguments.code ?? '';
+ *         const language = ctx.arguments.language ?? 'typescript';
+ *         return `Review this ${language} code:\n${code}`;
+ *     }
+ * });
+ * ```
+ */
+export declare class PromptInvocationContext {
+    /**
+     * Build a `PromptInvocationContext` from raw host-supplied trigger data.
+     * Accepts either a parsed object or a JSON string.
+     */
+    constructor(data: unknown);
+
+    /** The name of the prompt being invoked. */
+    readonly name: string;
+
+    /** Dictionary of prompt arguments (all values are strings). */
+    readonly arguments: Record<string, string>;
+
+    /** Optional session ID for the invocation. */
+    readonly sessionId: string | undefined;
+
+    /** Optional transport metadata. */
+    readonly transport: Record<string, unknown> | undefined;
+}

--- a/types/mcpPrompt.d.ts
+++ b/types/mcpPrompt.d.ts
@@ -55,6 +55,47 @@ export interface McpPromptArgument {
 }
 
 /**
+ * Fluent builder for declaring MCP prompt arguments in a record-shaped
+ * `promptArguments` map. The key of the map supplies the argument name.
+ *
+ * By default arguments are **optional**; call `.isRequired()` to mark them required.
+ *
+ * @example
+ * ```ts
+ * promptArguments: {
+ *     function_name: promptArg.describe('The function to document.').isRequired(),
+ *     style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
+ * }
+ * ```
+ */
+export declare class McpPromptArgumentBuilder {
+    /** Set the argument's description. */
+    describe(description: string): this;
+
+    /** Mark the argument as required. Default is optional. */
+    isRequired(): this;
+}
+
+/**
+ * Factory for creating MCP **prompt** argument builders.
+ *
+ * Kept separate from the tool-property `arg` helper because prompt arguments
+ * are untyped (only `name`, optional `description`, and a `required` flag).
+ */
+export declare const promptArg: {
+    /** Start building a prompt argument with a description. */
+    describe(description: string): McpPromptArgumentBuilder;
+};
+
+/**
+ * Accepted shapes for declaring prompt arguments.
+ *
+ * - **Array form** (explicit): an array of {@link McpPromptArgument} objects with `name`, optional `description` and `required`.
+ * - **Record/fluent form**: an object whose keys are argument names and values are {@link McpPromptArgumentBuilder} instances built from `promptArg.describe(...)`.
+ */
+export type McpPromptArguments = McpPromptArgument[] | Record<string, McpPromptArgumentBuilder>;
+
+/**
  * Configuration options for an MCP Prompt trigger.
  * These options define the behavior and metadata for the trigger.
  */
@@ -66,8 +107,12 @@ export interface McpPromptTriggerOptions {
 
     /**
      * Optional list of arguments the prompt accepts.
+     *
+     * Supports two shapes:
+     * - An array of {@link McpPromptArgument} objects (explicit `name`/`description`/`required`).
+     * - A record/fluent map built with `promptArg.describe(...)` where keys are argument names.
      */
-    promptArguments?: McpPromptArgument[];
+    promptArguments?: McpPromptArguments;
 
     /**
      * Optional human-readable title for display purposes.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -7,6 +7,7 @@ import { EventHubTrigger, EventHubTriggerOptions } from './eventHub';
 import { GenericTriggerOptions } from './generic';
 import { HttpTrigger, HttpTriggerOptions } from './http';
 import { FunctionTrigger } from './index';
+import { McpPromptFunctionOptions, McpPromptTrigger } from './mcpPrompt';
 import { McpResourceFunctionOptions, McpResourceTrigger } from './mcpResource';
 import { McpToolFunctionOptions, McpToolTrigger } from './mcpTool';
 import { MySqlTrigger, MySqlTriggerOptions } from './mySql';
@@ -102,6 +103,12 @@ export function mcpTool(options: McpToolFunctionOptions): McpToolTrigger;
  * [Link to docs and examples](//TODO Add link to docs and examples)
  */
 export function mcpResource(options: McpResourceFunctionOptions): McpResourceTrigger;
+
+/**
+ * Creates an MCP Prompt trigger for defining prompts that MCP clients can request.
+ * [Link to docs and examples](//TODO Add link to docs and examples)
+ */
+export function mcpPrompt(options: McpPromptFunctionOptions): McpPromptTrigger;
 
 /**
  * A generic option that can be used for any trigger type


### PR DESCRIPTION
Introduces MCP Prompt trigger support in the Node.js Functions library, with app.mcpPrompt / trigger.mcpPrompt, a typed PromptInvocationContext (name, arguments, sessionId, transport), and host-binding serialization of [promptArguments](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[metadata](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[icons](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Wires the new trigger through InvocationModel and the converter layer, and ships unit tests covering context parsing, RPC option conversion, and handler dispatch. Enables developers to author MCP prompts in TypeScript using the v4 programming model, paired with the [mcp-prompts](vscode-file://vscode-app/c:/Users/swapnilnagar/AppData/Local/Programs/Microsoft%20VS%20Code/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) sample in remote-mcp-functions-typescript.




```
app.mcpPrompt('GenerateDocumentation', {
    promptName: GenerateDocsPromptName,
    description: GenerateDocsPromptDescription,
    promptArguments: {
        function_name: promptArg.describe('The function to document.').isRequired(),
        style: promptArg.describe("Documentation style (e.g., 'concise', 'verbose')."),
    },
    handler: async (ctx: PromptInvocationContext, context: InvocationContext) => {
        const functionName = ctx.arguments.function_name ?? '(unknown)';
        const style = ctx.arguments.style ?? 'concise';

        context.log(`Generate docs prompt invoked for function: ${functionName}`);

        return [
            `Generate API documentation for the function named **${functionName}**.`,
            '',
            `Documentation style: **${style}**`,
            '',
            'Include the following sections:',
            '- **Description** \u2014 What the function does.',
            '- **Parameters** \u2014 List each parameter with its type and purpose.',
            '- **Return Value** \u2014 What the function returns.',
            '- **Example Usage** \u2014 A short code example showing how to call it.',
        ].join('\n');
    },
});;
```


