### PR TITLE
Adding the generic connector Trigger

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -128,6 +128,10 @@ export function eventGrid(name: string, options: EventGridFunctionOptions): void
     generic(name, convertToGenericOptions(options, trigger.eventGrid));
 }
 
+export function connectorTrigger<T = unknown>(name: string, options: ConnectorTriggerFunctionOptions<T>): void {
+    generic(name, convertToGenericOptions(options, trigger.connectorTrigger));
+}
+
 export function cosmosDB(name: string, options: CosmosDBFunctionOptions): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     generic(name, convertToGenericOptions(options, <any>trigger.cosmosDB));
@@ -180,10 +184,6 @@ export function mcpResource(name: string, options: McpResourceFunctionOptions): 
  */
 export function mcpPrompt(name: string, options: McpPromptFunctionOptions): void {
     generic(name, convertToGenericOptions(options, trigger.mcpPrompt));
-}
-
-export function connectorTrigger(name: string, options: ConnectorTriggerFunctionOptions): void {
-    generic(name, convertToGenericOptions(options, trigger.connectorTrigger));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+    ConnectorTriggerFunctionOptions,
     CosmosDBFunctionOptions,
     EventGridFunctionOptions,
     EventHubFunctionOptions,
@@ -179,6 +180,10 @@ export function mcpResource(name: string, options: McpResourceFunctionOptions): 
  */
 export function mcpPrompt(name: string, options: McpPromptFunctionOptions): void {
     generic(name, convertToGenericOptions(options, trigger.mcpPrompt));
+}
+
+export function connectorTrigger(name: string, options: ConnectorTriggerFunctionOptions): void {
+    generic(name, convertToGenericOptions(options, trigger.connectorTrigger));
 }
 
 export function generic(name: string, options: GenericFunctionOptions): void {

--- a/src/input.ts
+++ b/src/input.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import {
+    ConnectorContentInput,
+    ConnectorContentInputOptions,
     CosmosDBInput,
     CosmosDBInputOptions,
     FunctionInput,
@@ -67,6 +69,13 @@ export function webPubSubContext(options: WebPubSubContextInputOptions): WebPubS
     return addInputBindingName({
         ...options,
         type: 'webPubSubContext',
+    });
+}
+
+export function connectorContent(options: ConnectorContentInputOptions): ConnectorContentInput {
+    return addInputBindingName({
+        ...options,
+        type: 'connectorContent',
     });
 }
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import {
+    ConnectorContentOutput,
+    ConnectorContentOutputOptions,
     CosmosDBOutput,
     CosmosDBOutputOptions,
     EventGridOutput,
@@ -112,6 +114,13 @@ export function webPubSub(options: WebPubSubOutputOptions): WebPubSubOutput {
     return addOutputBindingName({
         ...options,
         type: 'webPubSub',
+    });
+}
+
+export function connectorContent(options: ConnectorContentOutputOptions): ConnectorContentOutput {
+    return addOutputBindingName({
+        ...options,
+        type: 'connectorContent',
     });
 }
 

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import {
+    ConnectorTrigger,
+    ConnectorTriggerOptions,
     CosmosDBTrigger,
     CosmosDBTriggerOptions,
     EventGridTrigger,
@@ -176,6 +178,13 @@ export function mcpPrompt(options: McpPromptTriggerOptions): McpPromptTrigger {
     return addTriggerBindingName({
         ...convertToMcpPromptTriggerOptionsToRpc(options),
         type: 'mcpPromptTrigger',
+    });
+}
+
+export function connectorTrigger(options: ConnectorTriggerOptions): ConnectorTrigger {
+    return addTriggerBindingName({
+        ...options,
+        type: 'connectorTrigger',
     });
 }
 

--- a/test/connectorTrigger.test.ts
+++ b/test/connectorTrigger.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { input, output, trigger } from '../src';
+import { toCoreFunctionMetadata } from '../src/converters/toCoreFunctionMetadata';
+import { InvocationContext } from '../types';
+
+describe('connectorTrigger', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const handler = (triggerInput: unknown, context: InvocationContext) => {};
+
+    describe('trigger.connectorTrigger', () => {
+        it('should create a trigger with correct type and options', () => {
+            const result = trigger.connectorTrigger({
+                connection: 'Office365Connection',
+                connector: 'office365',
+                triggerOperation: 'OnNewEmail',
+            });
+
+            expect(result.type).to.equal('connectorTrigger');
+            expect(result.connection).to.equal('Office365Connection');
+            expect(result.connector).to.equal('office365');
+            expect(result.triggerOperation).to.equal('OnNewEmail');
+            expect(result.name).to.be.a('string').and.not.be.empty;
+        });
+
+        it('should generate a consistent binding name', () => {
+            const options = {
+                connection: 'Office365Connection',
+                connector: 'office365',
+                triggerOperation: 'OnNewEmail',
+            };
+
+            const result1 = trigger.connectorTrigger(options);
+            const result2 = trigger.connectorTrigger(options);
+
+            expect(result1.name).to.equal(result2.name);
+        });
+
+        it('should generate different names for different options', () => {
+            const result1 = trigger.connectorTrigger({
+                connection: 'Office365Connection',
+                connector: 'office365',
+                triggerOperation: 'OnNewEmail',
+            });
+
+            const result2 = trigger.connectorTrigger({
+                connection: 'SharePointConnection',
+                connector: 'sharepointonline',
+                triggerOperation: 'OnNewFile',
+            });
+
+            expect(result1.name).to.not.equal(result2.name);
+        });
+    });
+
+    describe('toCoreFunctionMetadata with connectorTrigger', () => {
+        it('should produce correct metadata for connectorTrigger', () => {
+            const connectorTriggerBinding = trigger.connectorTrigger({
+                connection: 'Office365Connection',
+                connector: 'office365',
+                triggerOperation: 'OnNewEmail',
+            });
+
+            const result = toCoreFunctionMetadata('onNewEmail', {
+                handler,
+                trigger: connectorTriggerBinding,
+            });
+
+            expect(result).to.deep.equal({
+                name: 'onNewEmail',
+                bindings: {
+                    [connectorTriggerBinding.name]: {
+                        type: 'connectorTrigger',
+                        name: connectorTriggerBinding.name,
+                        direction: 'in',
+                        connection: 'Office365Connection',
+                        connector: 'office365',
+                        triggerOperation: 'OnNewEmail',
+                        properties: {
+                            supportsDeferredBinding: 'false',
+                        },
+                    },
+                },
+                retryOptions: undefined,
+            });
+        });
+
+        it('should produce correct metadata with connectorContent input and output', () => {
+            const connectorTriggerBinding = trigger.connectorTrigger({
+                connection: 'Office365Connection',
+                connector: 'office365',
+                triggerOperation: 'OnNewEmail',
+            });
+
+            const contentInput = input.connectorContent({
+                connector: 'office365',
+                connection: 'Office365Connection',
+                operation: 'GetEmail',
+            });
+
+            const contentOutput = output.connectorContent({
+                connector: 'office365',
+                connection: 'Office365Connection',
+                operation: 'SendEmail',
+            });
+
+            const result = toCoreFunctionMetadata('processEmail', {
+                handler,
+                trigger: connectorTriggerBinding,
+                extraInputs: [contentInput],
+                extraOutputs: [contentOutput],
+            });
+
+            expect(result).to.deep.equal({
+                name: 'processEmail',
+                bindings: {
+                    [connectorTriggerBinding.name]: {
+                        type: 'connectorTrigger',
+                        name: connectorTriggerBinding.name,
+                        direction: 'in',
+                        connection: 'Office365Connection',
+                        connector: 'office365',
+                        triggerOperation: 'OnNewEmail',
+                        properties: {
+                            supportsDeferredBinding: 'false',
+                        },
+                    },
+                    [contentInput.name]: {
+                        type: 'connectorContent',
+                        name: contentInput.name,
+                        direction: 'in',
+                        connector: 'office365',
+                        connection: 'Office365Connection',
+                        operation: 'GetEmail',
+                        properties: {
+                            supportsDeferredBinding: 'false',
+                        },
+                    },
+                    [contentOutput.name]: {
+                        type: 'connectorContent',
+                        name: contentOutput.name,
+                        direction: 'out',
+                        connector: 'office365',
+                        connection: 'Office365Connection',
+                        operation: 'SendEmail',
+                    },
+                },
+                retryOptions: undefined,
+            });
+        });
+    });
+});
+
+describe('connectorContent input', () => {
+    it('should create an input binding with correct type and options', () => {
+        const result = input.connectorContent({
+            connector: 'office365',
+            connection: 'Office365Connection',
+            operation: 'GetEmail',
+        });
+
+        expect(result.type).to.equal('connectorContent');
+        expect(result.connector).to.equal('office365');
+        expect(result.connection).to.equal('Office365Connection');
+        expect(result.operation).to.equal('GetEmail');
+        expect(result.name).to.be.a('string').and.not.be.empty;
+    });
+
+    it('should allow optional operation', () => {
+        const result = input.connectorContent({
+            connector: 'sharepointonline',
+            connection: 'SharePointConnection',
+        });
+
+        expect(result.type).to.equal('connectorContent');
+        expect(result.connector).to.equal('sharepointonline');
+        expect(result.connection).to.equal('SharePointConnection');
+        expect(result.operation).to.be.undefined;
+    });
+
+    it('should generate consistent binding names', () => {
+        const options = {
+            connector: 'office365',
+            connection: 'Office365Connection',
+            operation: 'GetEmail',
+        };
+
+        const result1 = input.connectorContent(options);
+        const result2 = input.connectorContent(options);
+
+        expect(result1.name).to.equal(result2.name);
+    });
+});
+
+describe('connectorContent output', () => {
+    it('should create an output binding with correct type and options', () => {
+        const result = output.connectorContent({
+            connector: 'office365',
+            connection: 'Office365Connection',
+            operation: 'SendEmail',
+        });
+
+        expect(result.type).to.equal('connectorContent');
+        expect(result.connector).to.equal('office365');
+        expect(result.connection).to.equal('Office365Connection');
+        expect(result.operation).to.equal('SendEmail');
+        expect(result.name).to.be.a('string').and.not.be.empty;
+    });
+
+    it('should allow optional operation', () => {
+        const result = output.connectorContent({
+            connector: 'teams',
+            connection: 'TeamsConnection',
+        });
+
+        expect(result.type).to.equal('connectorContent');
+        expect(result.connector).to.equal('teams');
+        expect(result.connection).to.equal('TeamsConnection');
+        expect(result.operation).to.be.undefined;
+    });
+
+    it('should generate consistent binding names', () => {
+        const options = {
+            connector: 'office365',
+            connection: 'Office365Connection',
+            operation: 'SendEmail',
+        };
+
+        const result1 = output.connectorContent(options);
+        const result2 = output.connectorContent(options);
+
+        expect(result1.name).to.equal(result2.name);
+    });
+});

--- a/test/connectorTrigger.test.ts
+++ b/test/connectorTrigger.test.ts
@@ -3,13 +3,12 @@
 
 import 'mocha';
 import { expect } from 'chai';
-import { input, output, trigger } from '../src';
+import { app, input, output, trigger } from '../src';
 import { toCoreFunctionMetadata } from '../src/converters/toCoreFunctionMetadata';
 import { InvocationContext } from '../types';
 
 describe('connectorTrigger', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const handler = (triggerInput: unknown, context: InvocationContext) => {};
+    const _handler = (_triggerInput: unknown, _context: InvocationContext) => {};
 
     describe('trigger.connectorTrigger', () => {
         it('should create a trigger with correct type and options', () => {
@@ -65,7 +64,7 @@ describe('connectorTrigger', () => {
             });
 
             const result = toCoreFunctionMetadata('onNewEmail', {
-                handler,
+                handler: _handler,
                 trigger: connectorTriggerBinding,
             });
 
@@ -108,7 +107,7 @@ describe('connectorTrigger', () => {
             });
 
             const result = toCoreFunctionMetadata('processEmail', {
-                handler,
+                handler: _handler,
                 trigger: connectorTriggerBinding,
                 extraInputs: [contentInput],
                 extraOutputs: [contentOutput],
@@ -150,6 +149,44 @@ describe('connectorTrigger', () => {
                 },
                 retryOptions: undefined,
             });
+        });
+    });
+
+    describe('app.connectorTrigger', () => {
+        it('should register without throwing', () => {
+            expect(() => {
+                app.connectorTrigger('testConnectorTrigger', {
+                    connection: 'Office365Connection',
+                    connector: 'office365',
+                    triggerOperation: 'OnNewEmail',
+                    handler: _handler,
+                });
+            }).to.not.throw();
+        });
+
+        it('should register with extraInputs and extraOutputs', () => {
+            const contentInput = input.connectorContent({
+                connector: 'office365',
+                connection: 'Office365Connection',
+                operation: 'GetEmail',
+            });
+
+            const contentOutput = output.connectorContent({
+                connector: 'office365',
+                connection: 'Office365Connection',
+                operation: 'SendEmail',
+            });
+
+            expect(() => {
+                app.connectorTrigger('testWithBindings', {
+                    connection: 'Office365Connection',
+                    connector: 'office365',
+                    triggerOperation: 'OnNewEmail',
+                    extraInputs: [contentInput],
+                    extraOutputs: [contentOutput],
+                    handler: _handler,
+                });
+            }).to.not.throw();
         });
     });
 });

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ConnectorTriggerFunctionOptions } from './connectorTrigger';
 import { CosmosDBFunctionOptions } from './cosmosDB';
 import { EventGridEvent, EventGridFunctionOptions } from './eventGrid';
 import { EventHubFunctionOptions } from './eventHub';
@@ -183,6 +184,13 @@ export function sql<T = unknown>(name: string, options: SqlFunctionOptions<T>): 
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function mySql<T = unknown>(name: string, options: MySqlFunctionOptions<T>): void;
+
+/**
+ * Registers a connector trigger function in your app that will be triggered by Azure Logic Apps connector events.
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the connector, connection, trigger operation, and handler for this function
+ */
+export function connectorTrigger(name: string, options: ConnectorTriggerFunctionOptions): void;
 
 /**
  * Registers a generic function in your app that will be triggered based on the type specified in `options.trigger.type`

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -160,6 +160,13 @@ export function eventGrid<T = EventGridEvent>(name: string, options: EventGridFu
 export function cosmosDB<T = unknown>(name: string, options: CosmosDBFunctionOptions<T>): void;
 
 /**
+ * Registers a connector trigger function in your app that will be triggered by Azure Logic Apps connector events.
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the connector, connection, trigger operation, and handler for this function
+ */
+export function connectorTrigger<T = unknown>(name: string, options: ConnectorTriggerFunctionOptions<T>): void;
+
+/**
  * Registers a function in your app that will be triggered when an instance is added to scale a running function app.
  * The warmup trigger is only called during scale-out operations, not during restarts or other non-scale startups.
  * Make sure your logic can load all required dependencies without relying on the warmup trigger.
@@ -184,13 +191,6 @@ export function sql<T = unknown>(name: string, options: SqlFunctionOptions<T>): 
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function mySql<T = unknown>(name: string, options: MySqlFunctionOptions<T>): void;
-
-/**
- * Registers a connector trigger function in your app that will be triggered by Azure Logic Apps connector events.
- * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
- * @param options Configuration options describing the connector, connection, trigger operation, and handler for this function
- */
-export function connectorTrigger(name: string, options: ConnectorTriggerFunctionOptions): void;
 
 /**
  * Registers a generic function in your app that will be triggered based on the type specified in `options.trigger.type`

--- a/types/connectorTrigger.d.ts
+++ b/types/connectorTrigger.d.ts
@@ -4,10 +4,12 @@
 import { FunctionInput, FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger, RetryOptions } from './index';
 import { InvocationContext } from './InvocationContext';
 
-export type ConnectorTriggerHandler = (triggerInput: unknown, context: InvocationContext) => FunctionResult;
+export type ConnectorTriggerHandler<T = unknown> = (triggerInput: T, context: InvocationContext) => FunctionResult;
 
-export interface ConnectorTriggerFunctionOptions extends ConnectorTriggerOptions, Partial<FunctionOptions> {
-    handler: ConnectorTriggerHandler;
+export interface ConnectorTriggerFunctionOptions<T = unknown>
+    extends ConnectorTriggerOptions,
+        Partial<FunctionOptions> {
+    handler: ConnectorTriggerHandler<T>;
 
     trigger?: ConnectorTrigger;
 

--- a/types/connectorTrigger.d.ts
+++ b/types/connectorTrigger.d.ts
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FunctionInput, FunctionOptions, FunctionOutput, FunctionResult, FunctionTrigger, RetryOptions } from './index';
+import { InvocationContext } from './InvocationContext';
+
+export type ConnectorTriggerHandler = (triggerInput: unknown, context: InvocationContext) => FunctionResult;
+
+export interface ConnectorTriggerFunctionOptions extends ConnectorTriggerOptions, Partial<FunctionOptions> {
+    handler: ConnectorTriggerHandler;
+
+    trigger?: ConnectorTrigger;
+
+    /**
+     * An optional retry policy to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.
+     * Learn more [here](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
+     */
+    retry?: RetryOptions;
+}
+
+export interface ConnectorTriggerOptions {
+    /**
+     * The connection setting name (maps to an app setting with the connector runtime URL).
+     */
+    connection: string;
+
+    /**
+     * The connector name (e.g., 'office365', 'sharepointonline', 'teams', 'kusto').
+     */
+    connector: string;
+
+    /**
+     * The trigger operation (e.g., 'OnNewEmail', 'OnNewFile', 'OnNewChannelMessage').
+     */
+    triggerOperation: string;
+}
+
+export type ConnectorTrigger = FunctionTrigger & ConnectorTriggerOptions;
+
+// ---------------------------------------------------------------------------
+// Connector content input binding
+// ---------------------------------------------------------------------------
+
+export interface ConnectorContentInputOptions {
+    /**
+     * The connector name (e.g., 'office365', 'sharepointonline', 'teams', 'kusto').
+     */
+    connector: string;
+
+    /**
+     * The connection setting name.
+     */
+    connection: string;
+
+    /**
+     * The operation to invoke on the connector (e.g., 'GetEmail', 'GetFile').
+     */
+    operation?: string;
+}
+
+export type ConnectorContentInput = FunctionInput & ConnectorContentInputOptions;
+
+// ---------------------------------------------------------------------------
+// Connector content output binding
+// ---------------------------------------------------------------------------
+
+export interface ConnectorContentOutputOptions {
+    /**
+     * The connector name (e.g., 'office365', 'sharepointonline', 'teams', 'kusto').
+     */
+    connector: string;
+
+    /**
+     * The connection setting name.
+     */
+    connection: string;
+
+    /**
+     * The operation to invoke on the connector (e.g., 'SendEmail', 'CreateFile').
+     */
+    operation?: string;
+}
+
+export type ConnectorContentOutput = FunctionOutput & ConnectorContentOutputOptions;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@
 import { InvocationContext } from './InvocationContext';
 
 export * as app from './app';
+export * from './connectorTrigger';
 export * from './cosmosDB';
 export * from './cosmosDB.v3';
 export * from './cosmosDB.v4';

--- a/types/input.d.ts
+++ b/types/input.d.ts
@@ -53,6 +53,7 @@ export function webPubSubContext(options: WebPubSubContextInputOptions): WebPubS
 
 /**
  * Creates a connector content input binding for reading data from an Azure Logic Apps connector.
+ * @param options Configuration options including the connector name, connection setting, and optional operation
  */
 export function connectorContent(options: ConnectorContentInputOptions): ConnectorContentInput;
 

--- a/types/input.d.ts
+++ b/types/input.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ConnectorContentInput, ConnectorContentInputOptions } from './connectorTrigger';
 import { CosmosDBInput, CosmosDBInputOptions } from './cosmosDB';
 import { GenericInputOptions } from './generic';
 import { FunctionInput } from './index';
@@ -49,6 +50,11 @@ export function webPubSubConnection(options: WebPubSubConnectionInputOptions): W
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-web-pubsub-input?pivots=programming-language-javascript)
  */
 export function webPubSubContext(options: WebPubSubContextInputOptions): WebPubSubContextInput;
+
+/**
+ * Creates a connector content input binding for reading data from an Azure Logic Apps connector.
+ */
+export function connectorContent(options: ConnectorContentInputOptions): ConnectorContentInput;
 
 /**
  * A generic option that can be used for any input type

--- a/types/output.d.ts
+++ b/types/output.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ConnectorContentOutput, ConnectorContentOutputOptions } from './connectorTrigger';
 import { CosmosDBOutput, CosmosDBOutputOptions } from './cosmosDB';
 import { EventGridOutput, EventGridOutputOptions } from './eventGrid';
 import { EventHubOutput, EventHubOutputOptions } from './eventHub';
@@ -78,6 +79,11 @@ export function mySql(options: MySqlOutputOptions): MySqlOutput;
  * [Link to docs and examples](https://docs.microsoft.com/azure/azure-functions/functions-bindings-web-pubsub-output?pivots=programming-language-javascript)
  */
 export function webPubSub(options: WebPubSubOutputOptions): WebPubSubOutput;
+
+/**
+ * Creates a connector content output binding for writing data to an Azure Logic Apps connector.
+ */
+export function connectorContent(options: ConnectorContentOutputOptions): ConnectorContentOutput;
 
 /**
  * A generic option that can be used for any output type

--- a/types/output.d.ts
+++ b/types/output.d.ts
@@ -82,6 +82,7 @@ export function webPubSub(options: WebPubSubOutputOptions): WebPubSubOutput;
 
 /**
  * Creates a connector content output binding for writing data to an Azure Logic Apps connector.
+ * @param options Configuration options including the connector name, connection setting, and optional operation
  */
 export function connectorContent(options: ConnectorContentOutputOptions): ConnectorContentOutput;
 

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -113,6 +113,7 @@ export function mcpPrompt(options: McpPromptFunctionOptions): McpPromptTrigger;
 
 /**
  * Creates a connector trigger configuration for Azure Logic Apps connector events.
+ * @param options Configuration options including the connector name, connection setting, and trigger operation
  */
 export function connectorTrigger(options: ConnectorTriggerOptions): ConnectorTrigger;
 

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ConnectorTrigger, ConnectorTriggerOptions } from './connectorTrigger';
 import { CosmosDBTrigger, CosmosDBTriggerOptions } from './cosmosDB';
 import { EventGridTrigger, EventGridTriggerOptions } from './eventGrid';
 import { EventHubTrigger, EventHubTriggerOptions } from './eventHub';
@@ -109,6 +110,11 @@ export function mcpResource(options: McpResourceFunctionOptions): McpResourceTri
  * [Link to docs and examples](//TODO Add link to docs and examples)
  */
 export function mcpPrompt(options: McpPromptFunctionOptions): McpPromptTrigger;
+
+/**
+ * Creates a connector trigger configuration for Azure Logic Apps connector events.
+ */
+export function connectorTrigger(options: ConnectorTriggerOptions): ConnectorTrigger;
 
 /**
  * A generic option that can be used for any trigger type


### PR DESCRIPTION
Adds native connectorTrigger, connectorContent input, and connectorContent output binding support to @azure/functions, enabling Azure Logic Apps connector events (Office 365, SharePoint, Teams, Kusto, etc.) to be registered as first-class function triggers and bindings on par with existing bindings like Cosmos DB, Event Hub, and Service Bus.