### PR TITLE
Bump @azure/function-extensions-base from 0.2.0 to 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ jspm_packages
 .node_repl_history
 azure-functions-language-worker-protobuf/*
 
+# IntelliJ
+.idea/
+
 dist
 out
 pkg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@azure/functions",
-    "version": "4.14.0",
+    "version": "4.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.14.0",
+            "version": "4.14.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             },
             "devDependencies": {
@@ -58,9 +58,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.14.0",
+    "version": "4.14.1",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",
@@ -41,7 +41,7 @@
         "watch": "webpack --watch --mode development"
     },
     "dependencies": {
-        "@azure/functions-extensions-base": "0.2.0",
+        "@azure/functions-extensions-base": "0.3.0",
         "cookie": "^0.7.0"
     },
     "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.14.0';
+export const version = '4.14.1';
 
 export const returnBindingKey = '$return';


### PR DESCRIPTION
Bumps the `@azure/functions-extensions-base` dependency so as to align with the version used in `@azure/functions-extensions-blob` and `@azure/functions-extensions-servicebus`. Otherwise, versions of `@azure/functions-extensions-blob` and `@azure/functions-extensions-servicebus` using `@azure/functions-extensions-base@0.3.0` will not function correctly due to the `ResourceFactoryResolver` singleton that's intended to be shared across `@azure/functions` and `@azure/functions-extensions-blob/servicebus` packages.