### PR TITLE
Harden HTTP proxy header handling

### DIFF
--- a/src/http/extractHttpUserFromHeaders.ts
+++ b/src/http/extractHttpUserFromHeaders.ts
@@ -3,6 +3,7 @@
 
 import { HttpRequestUser } from '@azure/functions';
 import { nonNullValue } from '../utils/nonNull';
+import { workerSystemLog } from '../utils/workerSystemLog';
 
 /* grandfathered in. Should fix when possible */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
@@ -12,7 +13,16 @@ export function extractHttpUserFromHeaders(headers: Headers): HttpRequestUser | 
 
     const clientPrincipal = headers.get('x-ms-client-principal');
     if (clientPrincipal) {
-        const claimsPrincipalData = JSON.parse(Buffer.from(clientPrincipal, 'base64').toString('utf-8'));
+        let claimsPrincipalData: any;
+        try {
+            claimsPrincipalData = JSON.parse(Buffer.from(clientPrincipal, 'base64').toString('utf-8'));
+        } catch (err) {
+            workerSystemLog(
+                'warning',
+                `Failed to parse x-ms-client-principal header: ${err instanceof Error ? err.message : String(err)}`
+            );
+            return null;
+        }
 
         if (claimsPrincipalData['identityProvider']) {
             user = {

--- a/src/http/extractHttpUserFromHeaders.ts
+++ b/src/http/extractHttpUserFromHeaders.ts
@@ -24,6 +24,15 @@ export function extractHttpUserFromHeaders(headers: Headers): HttpRequestUser | 
             return null;
         }
 
+        if (
+            claimsPrincipalData === null ||
+            typeof claimsPrincipalData !== 'object' ||
+            Array.isArray(claimsPrincipalData)
+        ) {
+            workerSystemLog('warning', 'Parsed x-ms-client-principal header was not a JSON object.');
+            return null;
+        }
+
         if (claimsPrincipalData['identityProvider']) {
             user = {
                 type: 'StaticWebApps',

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -25,7 +25,6 @@ const blockedProxyResponseHeaders = new Set([
     'trailers',
     'transfer-encoding',
     'upgrade',
-    'content-length',
 ]);
 
 const invocRequestEmitter = new EventEmitter();
@@ -52,8 +51,9 @@ const invocationIdHeader = 'x-ms-invocation-id';
 export async function sendProxyResponse(invocationId: string, userRes: HttpResponse): Promise<void> {
     const proxyRes = nonNullProp(responses, invocationId);
     delete responses[invocationId];
+    const connectionHeader = userRes.headers.get('connection');
     for (const [key, val] of userRes.headers.entries()) {
-        if (isAllowedProxyResponseHeader(key)) {
+        if (isAllowedProxyResponseHeader(key, connectionHeader)) {
             proxyRes.setHeader(key, val);
         }
     }
@@ -72,8 +72,21 @@ export async function sendProxyResponse(invocationId: string, userRes: HttpRespo
     proxyRes.end();
 }
 
-export function isAllowedProxyResponseHeader(headerName: string): boolean {
-    return !blockedProxyResponseHeaders.has(headerName.toLowerCase());
+export function isAllowedProxyResponseHeader(headerName: string, connectionHeader?: string | null): boolean {
+    const normalizedHeaderName = headerName.toLowerCase();
+    return (
+        !blockedProxyResponseHeaders.has(normalizedHeaderName) &&
+        !getConnectionHeaderNames(connectionHeader).has(normalizedHeaderName)
+    );
+}
+
+function getConnectionHeaderNames(connectionHeader?: string | null): Set<string> {
+    return new Set(
+        connectionHeader
+            ?.split(',')
+            .map((headerName) => headerName.trim().toLowerCase())
+            .filter((headerName) => headerName.length > 0)
+    );
 }
 
 function setCookies(userRes: HttpResponse, proxyRes: http.ServerResponse): void {

--- a/src/http/httpProxy.ts
+++ b/src/http/httpProxy.ts
@@ -15,6 +15,19 @@ const responses: Record<string, http.ServerResponse> = {};
 const minPort = 55000;
 const maxPort = 55025;
 
+const blockedProxyResponseHeaders = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'trailers',
+    'transfer-encoding',
+    'upgrade',
+    'content-length',
+]);
+
 const invocRequestEmitter = new EventEmitter();
 
 export async function waitForProxyRequest(invocationId: string): Promise<http.IncomingMessage> {
@@ -40,7 +53,9 @@ export async function sendProxyResponse(invocationId: string, userRes: HttpRespo
     const proxyRes = nonNullProp(responses, invocationId);
     delete responses[invocationId];
     for (const [key, val] of userRes.headers.entries()) {
-        proxyRes.setHeader(key, val);
+        if (isAllowedProxyResponseHeader(key)) {
+            proxyRes.setHeader(key, val);
+        }
     }
     proxyRes.setHeader(invocationIdHeader, invocationId);
     proxyRes.statusCode = userRes.status;
@@ -55,6 +70,10 @@ export async function sendProxyResponse(invocationId: string, userRes: HttpRespo
         }
     }
     proxyRes.end();
+}
+
+export function isAllowedProxyResponseHeader(headerName: string): boolean {
+    return !blockedProxyResponseHeaders.has(headerName.toLowerCase());
 }
 
 function setCookies(userRes: HttpResponse, proxyRes: http.ServerResponse): void {

--- a/test/http/extractHttpUserFromHeaders.test.ts
+++ b/test/http/extractHttpUserFromHeaders.test.ts
@@ -92,4 +92,24 @@ describe('Extract Http User Claims Principal from Headers', () => {
 
         expect(user).to.be.null;
     });
+
+    it('Returns null when client principal header parses to null', () => {
+        const headers: Headers = new Headers({
+            'x-ms-client-principal': Buffer.from(JSON.stringify(null)).toString('base64'),
+        });
+
+        const user: HttpRequestUser | null = extractHttpUserFromHeaders(headers);
+
+        expect(user).to.be.null;
+    });
+
+    it('Returns null when client principal header parses to a string', () => {
+        const headers: Headers = new Headers({
+            'x-ms-client-principal': Buffer.from(JSON.stringify('not an object')).toString('base64'),
+        });
+
+        const user: HttpRequestUser | null = extractHttpUserFromHeaders(headers);
+
+        expect(user).to.be.null;
+    });
 });

--- a/test/http/extractHttpUserFromHeaders.test.ts
+++ b/test/http/extractHttpUserFromHeaders.test.ts
@@ -82,4 +82,14 @@ describe('Extract Http User Claims Principal from Headers', () => {
 
         expect(user).to.be.null;
     });
+
+    it('Returns null when client principal header is not valid JSON', () => {
+        const headers: Headers = new Headers({
+            'x-ms-client-principal': Buffer.from('not json').toString('base64'),
+        });
+
+        const user: HttpRequestUser | null = extractHttpUserFromHeaders(headers);
+
+        expect(user).to.be.null;
+    });
 });

--- a/test/http/httpProxy.test.ts
+++ b/test/http/httpProxy.test.ts
@@ -14,9 +14,9 @@ describe('Http proxy', () => {
             'proxy-authorization',
             'te',
             'trailer',
+            'trailers',
             'transfer-encoding',
             'upgrade',
-            'content-length',
         ];
 
         for (const header of blockedHeaders) {
@@ -26,10 +26,18 @@ describe('Http proxy', () => {
     });
 
     it('Allows end-to-end response headers', () => {
-        const allowedHeaders = ['content-type', 'cache-control', 'set-cookie', 'x-frame-options'];
+        const allowedHeaders = ['content-type', 'cache-control', 'set-cookie', 'x-frame-options', 'content-length'];
 
         for (const header of allowedHeaders) {
             expect(isAllowedProxyResponseHeader(header), header).to.be.true;
         }
+    });
+
+    it('Blocks headers named by the Connection response header', () => {
+        const connectionHeader = 'keep-alive, x-private-hop, X-Another-Hop';
+
+        expect(isAllowedProxyResponseHeader('x-private-hop', connectionHeader)).to.be.false;
+        expect(isAllowedProxyResponseHeader('x-another-hop', connectionHeader)).to.be.false;
+        expect(isAllowedProxyResponseHeader('content-type', connectionHeader)).to.be.true;
     });
 });

--- a/test/http/httpProxy.test.ts
+++ b/test/http/httpProxy.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'mocha';
+import { expect } from 'chai';
+import { isAllowedProxyResponseHeader } from '../../src/http/httpProxy';
+
+describe('Http proxy', () => {
+    it('Blocks hop-by-hop response headers', () => {
+        const blockedHeaders = [
+            'connection',
+            'keep-alive',
+            'proxy-authenticate',
+            'proxy-authorization',
+            'te',
+            'trailer',
+            'transfer-encoding',
+            'upgrade',
+            'content-length',
+        ];
+
+        for (const header of blockedHeaders) {
+            expect(isAllowedProxyResponseHeader(header), header).to.be.false;
+            expect(isAllowedProxyResponseHeader(header.toUpperCase()), header).to.be.false;
+        }
+    });
+
+    it('Allows end-to-end response headers', () => {
+        const allowedHeaders = ['content-type', 'cache-control', 'set-cookie', 'x-frame-options'];
+
+        for (const header of allowedHeaders) {
+            expect(isAllowedProxyResponseHeader(header), header).to.be.true;
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- block hop-by-hop and framing response headers from the HTTP proxy response path
- handle invalid `x-ms-client-principal` payloads without failing the invocation
- add focused tests for proxy header filtering and invalid client principal JSON

## Notes
F4 (`ensureErrorType` object serialization) is intentionally not changed in this PR. That area needs a separate design discussion because the safer fix likely requires sanitizer behavior aligned with azure-functions-host and azure-functions-nodejs-worker, not just using an object's `message` property.

## Validation
- `npm test` (375 passed)
- `npm run lint`
