### PR TITLE
Updating CI for Node 24, 26 and removing for Node 18

### DIFF
--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -3,12 +3,14 @@ jobs:
 
       strategy:
           matrix:
-              Node18:
-                  NODE_VERSION: '18.x'
               Node20:
                   NODE_VERSION: '20.x'
               Node22:
                   NODE_VERSION: '22.x'
+              Node24:
+                  NODE_VERSION: '24.x'
+              Node26:
+                  NODE_VERSION: '26.x'
 
       steps:
           - task: NodeTool@0

--- a/package-lock.json
+++ b/package-lock.json
@@ -2880,6 +2880,20 @@
             "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",


### PR DESCRIPTION
## Update CI Node.js test matrix

### Summary

Update the CI pipeline to align with currently supported Node.js versions by removing Node 18 (EOL) and adding Node 24 and Node 26.

### Changes

- Removed Node.js 18 from the test matrix (reached end-of-life)
- Added Node.js 24 to the test matrix
- Added Node.js 26 to the test matrix

### Test Matrix (before → after)

| Before | After |
|--------|-------|
| Node 18 | Node 20 |
| Node 20 | Node 22 |
| Node 22 | Node 24 |
|          | Node 26 |

### Affected Files

- `azure-pipelines/templates/test.yml`

### Notes

- The `engines` field in `package.json` already requires `>=20.0`, consistent with dropping Node 18.
- The build step in `azure-pipelines/templates/build.yml` continues to use Node 20 for packaging.
