### PR TITLE
Release @azure/functions 3.5.2 with uuid 13.0.2

### DIFF
--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -3,16 +3,12 @@ jobs:
 
       strategy:
           matrix:
-              Node14:
-                  NODE_VERSION: '14.x'
-              Node16:
-                  NODE_VERSION: '16.x'
-              Node18:
-                  NODE_VERSION: '18.x'
               Node20:
                   NODE_VERSION: '20.x'
               Node22:
                   NODE_VERSION: '22.x'
+              Node24:
+                  NODE_VERSION: '24.x'
 
       steps:
           - task: NodeTool@0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@azure/functions",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "3.5.1",
+            "version": "3.5.2",
             "license": "MIT",
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "long": "^4.0.0",
-                "uuid": "^8.3.0"
+                "uuid": "^13.0.2"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -23,7 +23,6 @@
                 "@types/node": "^16.9.6",
                 "@types/semver": "^7.3.9",
                 "@types/sinon": "^7.0.0",
-                "@types/uuid": "^8.3.4",
                 "@typescript-eslint/eslint-plugin": "^5.12.1",
                 "@typescript-eslint/parser": "^5.12.1",
                 "chai": "^4.2.0",
@@ -455,12 +454,6 @@
             "version": "7.5.2",
             "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
             "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
-            "dev": true
-        },
-        "node_modules/@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4306,11 +4299,16 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {
@@ -4967,12 +4965,6 @@
             "version": "7.5.2",
             "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
             "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
-            "dev": true
-        },
-        "@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -7823,9 +7815,9 @@
             }
         },
         "uuid": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "long": "^4.0.0",
-        "uuid": "^8.3.0",
+        "uuid": "^13.0.2",
         "iconv-lite": "^0.6.3"
     },
     "devDependencies": {
@@ -51,7 +51,6 @@
         "@types/node": "^16.9.6",
         "@types/semver": "^7.3.9",
         "@types/sinon": "^7.0.0",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
         "chai": "^4.2.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '3.5.1';
+export const version = '3.5.2';
 
 export enum HeaderName {
     contentType = 'content-type',


### PR DESCRIPTION
## Summary
- Bump the v3 package version to 3.5.2
- Update the production `uuid` dependency to the patched `^13.0.2` release
- Preserve the existing v3 behavior by continuing to use `uuid.v4()` for generated UUID values
- Keep `src/constants.ts` in sync with the 3.5.2 package version
- Update the unit test CI matrix to Node `20/22/24`

## Node support note
- `uuid@13.0.2` is ESM-only for the older CommonJS require path used by this package output.
- Smoke checks showed `require('uuid')` fails with `ERR_REQUIRE_ESM` on Node v14.21.3, v16.20.2, and v18.20.8.
- Smoke checks showed `require('uuid')` succeeds on Node v20.19.5, v22.22.3, and v24.16.0.
- This PR therefore removes Node 14/16/18 from the unit test matrix and validates the package on Node 20+.

## Validation
- Node 14 negative check: `uuid@13.0.2` fails with `ERR_REQUIRE_ESM`
- Node 16 negative check: `uuid@13.0.2` fails with `ERR_REQUIRE_ESM`
- Node 18 negative check: `uuid@13.0.2` fails with `ERR_REQUIRE_ESM`
- Node 20 local matrix check: `npm ci`, `npm run updateVersion -- --validate`, `npm run build`, `npm run lint`, `npm test` (104 passing)
- Node 22 local matrix check: `npm ci`, `npm run updateVersion -- --validate`, `npm run build`, `npm run lint`, `npm test` (104 passing), `npm audit --omit=dev --audit-level=moderate --json` (0 production vulnerabilities)
- Node 24 local matrix check: `npm ci`, `npm run updateVersion -- --validate`, `npm run build`, `npm run lint`, `npm test` (104 passing)

Note: `npm pack` was intentionally not run here; Tsuyoshi will run it manually.