### PR TITLE
v3 compatibility experiment: uuid 8.3.2 + Node 16/18 matrix

### DIFF
--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -3,6 +3,10 @@ jobs:
 
       strategy:
           matrix:
+            Node16:
+              NODE_VERSION: '16.x'
+            Node18:
+              NODE_VERSION: '18.x'
               Node20:
                   NODE_VERSION: '20.x'
               Node22:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "long": "^4.0.0",
-                "uuid": "^13.0.2"
+                "uuid": "8.3.2"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
@@ -4299,16 +4299,13 @@
             }
         },
         "node_modules/uuid": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "license": "MIT",
             "bin": {
-                "uuid": "dist-node/bin/uuid"
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {
@@ -7815,9 +7812,9 @@
             }
         },
         "uuid": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
         "watch": "webpack --watch --mode development"
     },
     "dependencies": {
+        "iconv-lite": "^0.6.3",
         "long": "^4.0.0",
-        "uuid": "^13.0.2",
-        "iconv-lite": "^0.6.3"
+        "uuid": "8.3.2"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",


### PR DESCRIPTION
## Summary
- pin uuid from ^13.0.2 to 8.3.2 for CommonJS compatibility experiments
- add Node 16 and Node 18 to azure-pipelines/templates/test.yml matrix
- keep existing Node 20/22/24 jobs

## Validation
- npm test (pass locally)
- Node 16 require smoke: require('uuid') works
- Node 18 require smoke: require('uuid') works

## Security Note
- npm audit --omit=dev reports GHSA-w5hq-g745-h8pq on uuid < 11.1.1 (moderate)
- this PR is intended to validate compatibility/CI behavior, including whether security gates block this change
