### PR TITLE
build: onboard npm restores to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-pipelines/templates/build.yml
+++ b/azure-pipelines/templates/build.yml
@@ -14,6 +14,10 @@ jobs:
             inputs:
                 versionSpec: 20.x
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to Central Feed Service'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm audit --production

--- a/azure-pipelines/templates/npm-publish-steps.yml
+++ b/azure-pipelines/templates/npm-publish-steps.yml
@@ -9,6 +9,11 @@ steps:
     inputs:
       versionSpec: 18.x
 
+  - task: npmAuthenticate@0
+    displayName: 'Authenticate to Central Feed Service'
+    inputs:
+      workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
   - script: npm ci
     displayName: 'npm ci'
 

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -17,6 +17,10 @@ jobs:
             inputs:
                 versionSpec: $(NODE_VERSION)
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to Central Feed Service'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm run build


### PR DESCRIPTION
## Summary

- route npm dependency restores through the Azure Functions public Central Feed Service feed
- explicitly map the only scope in the complete resolved production graph (`@azure`)
- authenticate the checked-in source-root `.npmrc` before every reusable Azure Pipelines npm execution path
- preserve the existing npm publishing service connection and shipped package contents

## Audit

The repository has one npm project and no workspaces. Its resolved production graph contains `@azure/functions-extensions-base` and `cookie`, so `@azure` is the only production scope requiring an explicit mapping. All repository pipeline definitions, templates, scripts, global-install paths, and packaging inputs were reviewed. There are no NuGet, pip, uv, global npm install, or sudo npm restore paths to migrate. Lockfile URLs remain unchanged. The config contains no `always-auth`, `replace-registry-host`, or credentials.

## Validation

- restored with `npm ci --loglevel=http` from a truly empty cache under a path containing spaces
- observed 644 CFS requests and 388 Azure Artifacts blob requests, with zero `registry.npmjs.org` requests and zero HTTP 401 responses
- ran build, production webpack/minification, lint, version validation, unit tests, and production audit
- parsed all modified YAML and confirmed authentication precedes the first npm command in every template
- ran `npm pack --dry-run`, reproduced the pipeline-staged package, and validated the release script against a quoted drop path containing spaces
- confirmed `.npmrc`, lockfiles, credentials, pipeline files, tests, and build scripts are absent from the 96-file package

## Caveats and lessons

The feed requires authentication even for the public upstream route; local validation used an ephemeral user config outside the repository, while Azure Pipelines uses `npmAuthenticate@0`. The `Npm@1` publish task intentionally retains its existing npm publishing endpoint because it publishes the customer package rather than restoring dependencies. A default CFS registry handles unscoped and development dependencies, while the explicit scope mapping is derived only from the complete production graph.