### PR TITLE
ci: route npm restores through CFS registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -48,6 +48,10 @@ extends:
                           displayName: 'Install Node.js'
                           inputs:
                               versionSpec: 14.x
+                        - task: npmAuthenticate@0
+                          displayName: 'Authenticate to Central Feed Service'
+                          inputs:
+                              workingFile: '$(Build.SourcesDirectory)/.npmrc'
                         - script: npm ci
                           displayName: 'npm ci'
                         - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "$(Pipeline.Workspace)/officialBuild/drop"'

--- a/azure-pipelines/templates/build.yml
+++ b/azure-pipelines/templates/build.yml
@@ -14,6 +14,10 @@ jobs:
             inputs:
                 versionSpec: 20.x
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to Central Feed Service'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm audit --production

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -15,6 +15,10 @@ jobs:
             inputs:
                 versionSpec: $(NODE_VERSION)
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to Central Feed Service'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm run build


### PR DESCRIPTION
## Summary

Back-ports the CFS npm restore fix from `v4.x` commit `113f3a1` to `v3.x`.

- pins the default and `@azure` registries in the root `.npmrc` to the azfunc `upstream-public` CFS feed
- authenticates that `.npmrc` immediately before every executable `npm ci` in the build, test, and release pipelines
- leaves dependency manifests, the lockfile, and pipeline Node versions unchanged

## Coverage

The test template is reused by both Windows and Linux across the Node 20/22/24 matrix, so every `nodejs-library.public` test leg is covered. The build template also covers `nodejs-library.public` and `nodejs-library.official`; these definitions account for all 155 observed CFSClean failures for this repository.

There is exactly one `package.json`, at the repository root. Every restore uses the default working directory, so the root `.npmrc` applies to each path. The dormant release pipeline is also authenticated for its next run.

## Lockfile

`package-lock.json` is deliberately not regenerated. Its 802 `registry.npmjs.org` resolved URLs are registry-substitutable rather than literal fetch targets.

This was verified with Node 14.21.3 and npm 6.14.18 using a lockfileVersion-2 fixture whose `resolved` entry pointed to `registry.npmjs.org` while npm's registry was set to CFS. npm fetched metadata from `pkgs.dev.azure.com/.../upstream-public/npm/registry/` and the tarball from CFS's signed `vsblob.vsassets.io` redirect, with no request to `registry.npmjs.org`. A control run configured with an unreachable localhost registry failed against localhost instead of falling back to npmjs. This confirms the behavior even on npm 6, where the npm documentation does not explicitly describe it.

## Node version

`release.yml` intentionally remains on Node 14. It belongs to definition 611 (`nodejs-library.release`), which had zero builds in the observed 45-day period. The repository also has no unambiguous version to adopt: README lists 18/20, build uses 20, tests use 20/22/24, `package.json` requires >=22, and the lockfile root requires >=20. That pre-existing inconsistency, introduced in `7f26935`, should be addressed separately from CFS compliance.

## Known limitations

- A full local restore/build returns `E401` because local execution does not receive the CFS credential injected by Azure Pipelines through `npmAuthenticate@0`.
- Pipeline execution and `PermissiveCFSClean` telemetry cannot be verified until this change runs in Azure Pipelines.