### PR TITLE
build: migrate npm releases to shared ESRP template

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -1,0 +1,29 @@
+# Stable npm release pipeline
+
+`release.yml` publishes the `nodejs-library.official` build's unchanged `drop`
+artifact. It defaults to `NpmPublishDryRun: true`. A dry run validates the
+repository-specific npm tag/version rules and runs:
+
+```text
+npm publish <package.tgz> --tag <tag> --registry https://registry.npmjs.org --@azure:registry=https://registry.npmjs.org --dry-run --ignore-scripts
+```
+
+Set `NpmPublishDryRun: false` only after verifying the package version and npm
+tag. Real publishing delegates the unchanged `drop` artifact to the shared
+engineering `release-npm-package.yml` template with `publishMethod: esrp`. The
+dry-run path does not publish.
+
+## Azure DevOps configuration
+
+Create the `azure-functions-nodejs-library-release` variable group with:
+
+| Variable | Purpose |
+| --- | --- |
+| `EsrpOwners` | Individual Microsoft aliases that own the ESRP release, separated by commas or newlines. Distribution lists and security groups are not supported. |
+| `EsrpApprovers` | Individual Microsoft aliases that approve the ESRP release, separated by commas or newlines. These must differ from the owners. |
+| `EsrpManualApprovers` | Azure DevOps users or groups allowed to approve the manual validation before publishing. |
+
+Authorize `release.yml` to use the variable group, the internal `engineering`
+repository, the ESRP service connection, and the `nodejs-library.official`
+pipeline resource. Add `microsoft1es` and `microsoft-oss-releases` as read/write
+collaborators for the `@azure/functions` npm package.

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -17,11 +17,18 @@ resources:
           type: git
           name: 1ESPipelineTemplates/1ESPipelineTemplates
           ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/tags/release
     pipelines:
         - pipeline: officialBuild
           project: internal
           source: nodejs-library.official
           branch: v4.x
+
+variables:
+    - group: azure-functions-nodejs-library-release
 
 extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -41,11 +48,21 @@ extends:
                   image: 1es-ubuntu-22.04
                   os: linux
               jobs:
-                  - job: Release
-                    steps:
-                        - download: officialBuild
-                        - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                  - ${{ if eq(parameters.NpmPublishDryRun, true) }}:
+                        - job: ValidateRelease
+                          displayName: 'Validate npm release'
+                          steps:
+                              - download: officialBuild
+                              - template: /azure-pipelines/templates/npm-publish-dry-run-steps.yml@self
+                                parameters:
+                                    tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
+                                    NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                  - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
+                        - template: /ci/release-npm-package.yml@eng
                           parameters:
-                            tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
-                            NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                            NpmPublishDryRun: ${{ parameters.NpmPublishDryRun }}
+                              artifact:
+                                  name: drop
+                                  pipeline: officialBuild
+                              publishMethod: esrp
+                              esrpNpmTag: ${{ parameters.NpmPublishTag }}
+                              approvers: '$(EsrpManualApprovers)'

--- a/azure-pipelines/templates/npm-publish-dry-run-steps.yml
+++ b/azure-pipelines/templates/npm-publish-dry-run-steps.yml
@@ -1,0 +1,36 @@
+parameters:
+    - name: tgzPath
+      type: string
+    - name: NpmPublishTag
+      type: string
+
+steps:
+    - pwsh: |
+          $packages = @(Get-ChildItem -Path '${{ parameters.tgzPath }}' -File -Filter '*.tgz')
+          if ($packages.Count -ne 1) {
+              throw "Expected exactly one npm package in '${{ parameters.tgzPath }}'; found $($packages.Count)."
+          }
+
+          Write-Host "Using npm package $($packages[0].FullName)"
+          Write-Host "##vso[task.setvariable variable=npmPackagePath]$($packages[0].FullName)"
+      displayName: 'Validate npm package artifact'
+
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+          versionSpec: 20.x
+
+    - task: npmAuthenticate@0
+      displayName: 'Authenticate to Central Feed Service'
+      inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+    - script: npm ci
+      displayName: 'npm ci'
+
+    - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "${{ parameters.tgzPath }}"'
+      displayName: 'Validate release'
+      name: validateReleaseStep
+
+    - script: npm publish "$(npmPackagePath)" --tag "${{ parameters.NpmPublishTag }}" --registry "https://registry.npmjs.org" --@azure:registry="https://registry.npmjs.org" --dry-run --ignore-scripts
+      displayName: 'Validate npm publish (dry run)'


### PR DESCRIPTION
## Summary

- migrate real npm publishing in the stable `release.yml` pipeline to the shared engineering `/ci/release-npm-package.yml@eng` template with `publishMethod: esrp`
- keep dry runs local and non-publishing with the repository's tag/version validation plus `npm publish --dry-run --ignore-scripts`
- leave the existing pre-release pipeline and its publishing behavior unchanged
- document the Azure DevOps and npm operational setup

This follows the shared ESRP npm release pattern introduced in Azure/azure-functions-skills#213 and its current `main` pipeline definitions.

## Validation

- `npm test`
- `npm run build`
- parsed all changed YAML with `js-yaml`
- checked changed templates/docs with the repository Prettier configuration
- packed `@azure/functions@4.16.3`, ran `validateRelease` for the `latest` tag, and completed `npm publish --dry-run --ignore-scripts` against `registry.npmjs.org`
- confirmed `pre-release.yml` and its existing npm publish template are unchanged from `v4.x`

## Operational setup required

Before running `release.yml` with `NpmPublishDryRun: false`:

- create the `azure-functions-nodejs-library-release` variable group with `EsrpOwners`, `EsrpApprovers`, and `EsrpManualApprovers`; owners and approvers must be individual Microsoft aliases and must not overlap
- authorize the release pipeline to use that variable group, the internal `engineering` repository resource at `refs/tags/release`, the ESRP service connection, and the `nodejs-library.official` pipeline resource
- add `microsoft1es` and `microsoft-oss-releases` as read/write collaborators for the `@azure/functions` npm package