### PR TITLE
Add SDK binding option for Service Bus topic triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions",
-    "version": "4.16.3",
+    "version": "4.16.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions",
-            "version": "4.16.3",
+            "version": "4.16.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions",
-    "version": "4.16.3",
+    "version": "4.16.4",
     "description": "Microsoft Azure Functions NodeJS Framework",
     "keywords": [
         "azure",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '4.16.3';
+export const version = '4.16.4';
 
 export const returnBindingKey = '$return';

--- a/test/Types.test.ts
+++ b/test/Types.test.ts
@@ -10,7 +10,7 @@ describe('Public TypeScript types', () => {
     for (const tsVersion of ['4']) {
         it(`builds with TypeScript v${tsVersion}`, async function (this: Context) {
             this.timeout(60 * 1000);
-            expect(await runTsBuild(tsVersion)).to.equal(2);
+            expect(await runTsBuild(tsVersion)).to.equal(0);
         });
     }
 });

--- a/test/converters/toCoreFunctionMetadata.test.ts
+++ b/test/converters/toCoreFunctionMetadata.test.ts
@@ -303,6 +303,44 @@ describe('toCoreFunctionMetadata sdk binding tests', () => {
         });
     });
 
+    for (const testCase of [
+        { sdkBinding: true, expectedDeferredBinding: 'true' },
+        { sdkBinding: false, expectedDeferredBinding: 'false' },
+        { sdkBinding: undefined, expectedDeferredBinding: 'false' },
+    ] as const) {
+        it(`should set supportsDeferredBinding to ${
+            testCase.expectedDeferredBinding
+        } for service bus topic trigger when sdkBinding is ${String(testCase.sdkBinding)}`, () => {
+            const result = toCoreFunctionMetadata('serviceBusTopicFunction', {
+                handler,
+                trigger: trigger.serviceBusTopic({
+                    topicName: 'topic',
+                    subscriptionName: 'subscription',
+                    connection: 'ServiceBusConnection',
+                    ...(testCase.sdkBinding === undefined ? {} : { sdkBinding: testCase.sdkBinding }),
+                }),
+            });
+
+            const serviceBusTopicBinding = Object.values(result.bindings).find(
+                (binding) => binding.type === 'serviceBusTrigger'
+            );
+
+            expect(serviceBusTopicBinding).to.deep.include({
+                topicName: 'topic',
+                subscriptionName: 'subscription',
+                connection: 'ServiceBusConnection',
+                properties: {
+                    supportsDeferredBinding: testCase.expectedDeferredBinding,
+                },
+            });
+            if (testCase.sdkBinding === undefined) {
+                expect(serviceBusTopicBinding).not.to.have.property('sdkBinding');
+            } else {
+                expect(serviceBusTopicBinding).to.have.property('sdkBinding', testCase.sdkBinding);
+            }
+        });
+    }
+
     it('should handle sdk binding for extra inputs', () => {
         const result = toCoreFunctionMetadata('funcName', {
             handler,

--- a/test/converters/toCoreFunctionMetadata.test.ts
+++ b/test/converters/toCoreFunctionMetadata.test.ts
@@ -341,6 +341,31 @@ describe('toCoreFunctionMetadata sdk binding tests', () => {
         });
     }
 
+    it('should not enable deferred binding for null or malformed service bus topic sdkBinding values', () => {
+        const invalidSdkBindingValues: unknown[] = [null, 0, 1, '', 'true', {}, []];
+
+        for (const sdkBinding of invalidSdkBindingValues) {
+            const result = toCoreFunctionMetadata('serviceBusTopicFunction', {
+                handler,
+                trigger: {
+                    type: 'serviceBusTrigger',
+                    name: 'serviceBusTopicTrigger',
+                    topicName: 'topic',
+                    subscriptionName: 'subscription',
+                    connection: 'ServiceBusConnection',
+                    sdkBinding,
+                },
+            });
+
+            expect(result.bindings['serviceBusTopicTrigger']).to.deep.include({
+                sdkBinding,
+                properties: {
+                    supportsDeferredBinding: 'false',
+                },
+            });
+        }
+    });
+
     it('should handle sdk binding for extra inputs', () => {
         const result = toCoreFunctionMetadata('funcName', {
             handler,

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -39,6 +39,37 @@ const fullFidelityOptions: CosmosDBv4FullFidelityFunctionOptions<TodoItem> = {
     },
 };
 
+type ServiceBusTopicFunctionOptions<T = unknown> = import('../../types').ServiceBusTopicFunctionOptions<T>;
+type ServiceBusTopicTriggerOptions = import('../../types').ServiceBusTopicTriggerOptions;
+
+const serviceBusTopicTriggerOptions: ServiceBusTopicTriggerOptions = {
+    connection: 'ServiceBusConnection',
+    topicName: 'topic',
+    subscriptionName: 'subscription',
+    sdkBinding: true,
+};
+
+const serviceBusTopicFunctionOptions: ServiceBusTopicFunctionOptions<string> = {
+    ...serviceBusTopicTriggerOptions,
+    handler: (message) => {
+        const typedMessage: string = message;
+        void typedMessage;
+    },
+};
+
+const invalidServiceBusTopicTriggerOptions: ServiceBusTopicTriggerOptions = {
+    connection: 'ServiceBusConnection',
+    topicName: 'topic',
+    subscriptionName: 'subscription',
+    // @ts-expect-error sdkBinding only accepts boolean values
+    sdkBinding: 'true',
+};
+
+declare const app: typeof import('../../types').app;
+function registerServiceBusTopic(): void {
+    app.serviceBusTopic<string>('serviceBusTopic', serviceBusTopicFunctionOptions);
+}
+
 type ExpectedAvadHandler = import('../../types').CosmosDBv4Handler<CosmosDBChangeFeedItem<TodoItem>>;
 type ValidAvadHandler = (
     documents: CosmosDBChangeFeedItem<TodoItem>[],
@@ -57,5 +88,9 @@ const invalidHandlerAssignableToAvad: IsInvalidHandlerAssignableToAvad = false;
 
 void latestVersionOptions;
 void fullFidelityOptions;
+void serviceBusTopicTriggerOptions;
+void serviceBusTopicFunctionOptions;
+void invalidServiceBusTopicTriggerOptions;
+void registerServiceBusTopic;
 void validHandlerAssignableToAvad;
 void invalidHandlerAssignableToAvad;

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -3,6 +3,8 @@
         "module": "commonjs",
         "target": "es6",
         "strict": true,
+        "skipLibCheck": true,
+        "types": ["mocha"],
         "outDir": "dist",
         "baseUrl": "./",
         "paths": {

--- a/types/serviceBus.d.ts
+++ b/types/serviceBus.d.ts
@@ -43,7 +43,7 @@ export interface ServiceBusQueueTriggerOptions {
     cardinality?: 'many' | 'one';
 
     /**
-     * Whether to use sdk binding for this blob operation.
+     * Whether to use SDK binding for this Service Bus trigger.
      * */
     sdkBinding?: boolean;
 }
@@ -97,6 +97,11 @@ export interface ServiceBusTopicTriggerOptions {
      * Set to `many` in order to enable batching. If omitted or set to `one`, a single message is passed to the function.
      */
     cardinality?: 'many' | 'one';
+
+    /**
+     * Whether to use SDK binding for this Service Bus trigger.
+     */
+    sdkBinding?: boolean;
 }
 export type ServiceBusTopicTrigger = FunctionTrigger & ServiceBusTopicTriggerOptions;
 


### PR DESCRIPTION
Service Bus topic functions could not enable SDK bindings through the public TypeScript API because `sdkBinding` was missing from `ServiceBusTopicTriggerOptions`. This prevented topic-trigger users of `@azure/functions-extensions-servicebus` from opting into deferred SDK binding behavior described in Azure/azure-functions-nodejs-extensions#153.

This change adds the option with parity to Service Bus queue triggers and verifies that topic metadata emits the expected deferred-binding flag when the option is true, false, omitted, null, or malformed. Only the literal boolean `true` enables deferred binding. It also makes the TypeScript 4 compatibility test compile the public type fixture successfully instead of treating unrelated dependency parse errors as the expected result, and bumps the library version to `4.16.4`.

## Testing

- Full unit test suite
- TypeScript 4 public type compatibility test
- Webpack build
- Version consistency validation
- ESLint and Prettier checks